### PR TITLE
OpenSSH server requirements

### DIFF
--- a/design/ssh_server_requirements.lando
+++ b/design/ssh_server_requirements.lando
@@ -13,9 +13,6 @@ attestation and assertion signatures.
 Open_sshd_config
 OpenSSH server requires an default configured sshd_config file. 
 
-Open_ssh_primes_moduli
-The binary OpenSSH also set-up primes and moduli.
-
 Open_ssh_keygen
 The install also provides authentication keys by 
 standard mechanism ssh-keygen.


### PR DESCRIPTION
High level of spec for  openssh version 7.3 server. The main idea is to cover CWE/CVE vulnerabilities from the [spreadsheet](https://docs.google.com/spreadsheets/d/1HL0mfAd0Hm5-ad097WBsTJcRSobZc8OgAAkjehQ7Hmw/edit#gid=956930634) labeled as openssh.  
The related issue is : https://github.com/DARPA-SSITH-Demonstrators/SSITH-FETT-Target/issues/70