### PR TITLE
Fix small bug in prepareDebian

### DIFF
--- a/fett/target/build.py
+++ b/fett/target/build.py
@@ -109,7 +109,7 @@ def prepareFreeRTOS():
 def prepareDebian():
     # copy the crngOnDebian.riscv
     cp (getSetting('addEntropyDebianPath'),getSetting('buildDir'))
-    importImage('debian')
+    importImage()
 
 @decorate.debugWrap
 @decorate.timeWrap


### PR DESCRIPTION
`prepareDebian` was calling `importImage` with an argument even though none is expected. This change simply removes that argument.