### PR TITLE
do not change root PW on busybox

### DIFF
--- a/fett/target/launch.py
+++ b/fett/target/launch.py
@@ -89,7 +89,8 @@ def launchFett ():
     xTarget = getClassType()()
     xTarget.start()
     if (isEnabled('isUnix')):
-        xTarget.changeRootPassword()
+        if (getSetting('osImage') in ['debian','FreeBSD']):
+            xTarget.changeRootPassword()
         xTarget.createUser()
     if (isEnabled('runApp')):
         xTarget.runApp(sendFiles=isEnabled('sendTarballToTarget'))


### PR DESCRIPTION
The function changeRootPassword does not have an implementation for busybox, and it shouldn't. But the function is called anyway. This fixes it.