### PR TITLE
Move FAT init to main_fett

### DIFF
--- a/fett/target/srcFreeRTOS/main_fett.c
+++ b/fett/target/srcFreeRTOS/main_fett.c
@@ -13,6 +13,10 @@ void main_fett () {
 
     printf ("\n>>>Beginning of Fett<<<\n");
 
+    //Start the FAT filesystem
+    funcReturn = ff_init();
+    prERROR_IF_NEQ(funcReturn, 0, "main_fett: Initializing FAT filesystem."); 
+
     BaseType_t funcReturn = xTaskCreate(vMain, "main:vMain", configMINIMAL_STACK_SIZE * STACKSIZEMUL, NULL, xMainPriority, NULL);
     prERROR_IF_NEQ(funcReturn, pdPASS, "main_fett: Creating vMain task.");
 
@@ -35,10 +39,6 @@ void vMain (void *pvParameters) {
     funcReturn = xTaskNotifyWait(0xffffffff, 0xffffffff, &recvNotification, pdMS_TO_TICKS(20000)); //it usually takes 10-15 seconds
     vERROR_IF_NEQ(funcReturn, pdPASS, "vMain: Receive notification from vStartNetwork.");
     vERROR_IF_NEQ(recvNotification, NOTIFY_SUCCESS_NTK, "vMain: Expected notification value from vStartNetwork.");
-
-    //Start the FAT filesystem
-    funcReturn = ff_init();
-    prERROR_IF_NEQ(funcReturn, 0, "main_fett: Initializing FAT filesystem."); 
 
     //Start the HTTP task
     funcReturn = xTaskCreate(vHttp, "vMain:vHttp", configMINIMAL_STACK_SIZE * STACKSIZEMUL, NULL, xMainPriority, NULL);


### PR DESCRIPTION
This moves the FAT init logic to main_fett as it has minimal dependencies and should likely be started up early on in during startup.