### PR TITLE
Fix: SD on FreeRTOS 

### DIFF
--- a/fett/target/srcFreeRTOS/main_fett.c
+++ b/fett/target/srcFreeRTOS/main_fett.c
@@ -30,7 +30,7 @@ void vMain (void *pvParameters) {
 
     //Start the FAT filesystem
     funcReturn = ff_init();
-    prERROR_IF_NEQ(funcReturn, 0, "main_fett: Initializing FAT filesystem."); 
+    vERROR_IF_NEQ(funcReturn, 0, "main_fett: Initializing FAT filesystem."); 
 
     funcReturn = xTaskCreate(vStartNetwork, "vMain:startNetwork", configMINIMAL_STACK_SIZE * STACKSIZEMUL, NULL, xMainPriority, NULL);
     vERROR_IF_NEQ(funcReturn, pdPASS, "vMain: Creating vStartNetwork task.");


### PR DESCRIPTION
Fixes #224 

Made the codes work, and tested it on a real SD and the FPGA.

This is the test:
```c
// Write to the file
FF_FILE * xFileW = ff_fopen( "test3.txt", (char *) 'w' );
vERROR_IF_EQ(xFileW, NULL, "main_fett: Opening a file for writing."); 

const char * xTextw = "This is test#3\nAnd this is the second line\n";
size_t xSize = ff_fwrite( (void *) xTextw, 1, strlen(xTextw), xFileW );
fettPrintf("main_fett: output of ff_fwrite=<%ld>\n",xSize);

funcReturn = ff_fclose( xFileW );
vERROR_IF_EQ(funcReturn, 1, "main_fett: Closing the file after writing."); 

//Read from the file
FF_FILE * xFileR = ff_fopen( "test3.txt", (char *) 'r' );
vERROR_IF_EQ(xFileR, NULL, "main_fett: Opening a file for reading."); 

char xTextr[100];
xSize = ff_fread( (void *) xTextr, 1, 100, xFileR );
if (xSize >= 100) {
        xTextr[99] = '\0';
} else {
    xTextr[xSize] = '\0';
}
fettPrintf("main_fett: Read: <%s>. output of ff_fread=<%ld>\n",xTextr,xSize);

funcReturn = ff_fclose( xFileR );
vERROR_IF_EQ(funcReturn, 1, "main_fett: Closing the file after reading."); 
```

And that was the output:
```
(Info)~  main_fett: Opening a file for writing.
main_fett: output of ff_fwrite=<43>
(Info)~  main_fett: Closing the file after writing.
(Info)~  main_fett: Opening a file for reading.
main_fett: Read: <This is test#3
And this is the second line
This is test#3
And this is the second line
>. output of ff_fread=<86>
(Info)~  main_fett: Closing the file after reading.
```

Note that the writes are persistent. And that there are no `pcMode` in ff_stdio. We'll have to open issues for determinism.