### PR TITLE
Revert "Disable nginx options that case FreeBSD to panic"

### DIFF
--- a/build/webserver/common/conf/nginx.conf
+++ b/build/webserver/common/conf/nginx.conf
@@ -9,8 +9,8 @@ http {
     ssl_certificate_key /etc/ssl/private/private-selfsigned.key;
 
     # faster connections for existing clients -- session resumption
-    # ssl_session_timeout 1d;
-    # ssl_session_cache shared:SSL:50m; # share between nginx workers
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:50m; # share between nginx workers
 
     # mozilla suggested configuration
     ssl_protocols               TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;


### PR DESCRIPTION
The FreeBSD pmap bug has been fixed and the fix is present in CheriBSD
and the freebsd-crossbuild branches.

This reverts commit af142326dfa339e13d864486152e14a4374e11b3.