### PR TITLE
HTTP in lando

### DIFF
--- a/design/fett_p2.lando
+++ b/design/fett_p2.lando
@@ -34,6 +34,7 @@ The Web Server application.
     including attached files.
   Web Server must log all connections and connection attempts.
   Web Server must support execution of external programs (via CGI or similar mechanism).  
+  Execute HTTP Method!
   Execute HTTPS Method!
 
 component DatabaseCLI


### PR DESCRIPTION
We're serving http as well as https; this should be reflected in the high level specification.