### PR TITLE
Develop branch for scheduled workflows

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,3 +1,7 @@
+# All scheduled jobs only run on the master branch. Consequently, any changes
+# to this file will not be refelcted in the CI until it is merged to master.
+#
+# To run the workflow on the develop branch, develop is checked out manually.
 name: Scheduled Runs
 on:
   schedule:


### PR DESCRIPTION
Like other changes to the scheduled workflow, this one won't take effect until develop is merged into master. I will attempt to verify that this will do the right thing on a separate testing repo somewhere