### PR TITLE
Fix permission error GitHub actions

### DIFF
--- a/.github/action/entrypoint.sh
+++ b/.github/action/entrypoint.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -Eeuo pipefail
-
-exec "$@"

--- a/.github/action/index.js
+++ b/.github/action/index.js
@@ -48,7 +48,6 @@ try {
       "--user=root",
       "--network=host",
       "--workdir /github/workspace",
-      "--entrypoint .github/action/entrypoint.sh",
       ...env,
       "-v /var/run/docker.sock:/var/run/docker.sock",
       `-v ${work}/_temp/_github_home:/github/home`,


### PR DESCRIPTION
As a happy side effect, this should solve the spurious errors we were getting on boron because boron has a different homedir than everything else and who would've thought that would end up breaking weird hacks?