### PR TITLE
cherry-pick the .github folder from develop

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -6,6 +6,9 @@ name: Scheduled Runs
 on:
   schedule:
     - cron: "0 0 * * *"
+  push:
+    branches:
+      - "actions/*"
 
 jobs:
   Periodic:
@@ -25,11 +28,18 @@ jobs:
           - { os: freertos, index: 1, total: 1, host: docker-fpga-io }
     steps:
       - uses: actions/checkout@v2
+        if: github.event_name == 'schedule'
         with:
           submodules: recursive
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
           lfs: true
           ref: "develop"
+      - uses: actions/checkout@v2
+        if: github.event_name == 'push'
+        with:
+          submodules: recursive
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          lfs: true
       - uses: ./.github/action
         with:
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -58,11 +68,18 @@ jobs:
           - { os: freertos, index: 1, total: 1, host: docker-fpga-io }
     steps:
       - uses: actions/checkout@v2
+        if: github.event_name == 'schedule'
         with:
           submodules: recursive
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
           lfs: true
           ref: "develop"
+      - uses: actions/checkout@v2
+        if: github.event_name == 'push'
+        with:
+          submodules: recursive
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          lfs: true
       - uses: ./.github/action
         with:
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
When this is merged in, we'll be able to test any changes to the scheduled workflow by pushing to any branch that starts with `actions/`. That should reduce the need to explicitly pick things off into master before `develop` is ready to be merged into it.