### PR TITLE
Voting cleanup

### DIFF
--- a/fett/apps/unix/database.py
+++ b/fett/apps/unix/database.py
@@ -21,6 +21,14 @@ def install(target):
 
 @decorate.debugWrap
 @decorate.timeWrap
+def sqliteCmd(target, sqlite_bin, xDb, cmd, tee=None, expectedContents=None, shutdownOnError=True, suppressErrors=False):
+    return target.runCommand(f"{sqlite_bin} {xDb} \"{cmd}\"",
+                             expectedContents=expectedContents,
+                             suppressErrors=suppressErrors,
+                             shutdownOnError=shutdownOnError,
+                             erroneousContents=["Error:","near","error"],
+                             tee=tee)
+
 def deploymentTest(target):
     appLog = getSetting('appLog')
     printAndLog("Testing sqlite...",tee=appLog)
@@ -29,30 +37,28 @@ def deploymentTest(target):
     tableName = 'food'
     foodstuff = 'Pancakes'
     target.switchUser()
-    
+
+    # Close over locals for brevity
+    def sqlite_test(cmd, expectedContents=None, shutdownOnError=True, suppressErrors=False):
+        return sqliteCmd(target, sqlite_bin, xDb, cmd,
+                         expectedContents=expectedContents,
+                         shutdownOnError=shutdownOnError,
+                         suppressErrors=suppressErrors,
+                         tee=appLog)
 
     def create_database_and_table(xTable=tableName):
         printAndLog(f"Test[create_database_and_table]: Create sqlite {xDb} database and {xTable} table", doPrint=False,tee=getSetting('appLog'))
-        target.runCommand(f"{sqlite_bin} {xDb}", expectedContents=["SQLite version", ".help"],
-                                      erroneousContents=["Error:","near","error"], endsWith="sqlite>",tee=appLog)
-        target.runCommand(f"CREATE VIRTUAL TABLE IF NOT EXISTS {xTable} USING fts3(title);",
-                                      endsWith="sqlite>",tee=appLog)
-        target.runCommand(".tables", expectedContents=[f"{xTable}"], endsWith="sqlite>",tee=appLog)
-        target.runCommand(".exit",tee=appLog)
+        sqlite_test(f"CREATE VIRTUAL TABLE IF NOT EXISTS {xTable} USING fts3(title);")
+        sqlite_test(".tables", expectedContents=[f"{xTable}"])
         printAndLog(f"Test[create_database_and_table]: The {xDb} database and {xTable} table created successfully!",
                     doPrint=False,tee=getSetting('appLog'))
         return
 
     def insert_record(xTable=tableName, title_val=foodstuff):
         printAndLog(f"Test[insert_record]: Insert into  {xTable} table value {title_val}.", doPrint=False,tee=getSetting('appLog'))
-        target.runCommand(f"{sqlite_bin} {xDb}", expectedContents=["SQLite version", ".help"],
-                                      endsWith="sqlite>",tee=appLog)
-        target.runCommand(".tables", expectedContents=[f"{xTable}"], endsWith="sqlite>",tee=appLog)
-        target.runCommand(f"INSERT INTO {xTable}(title) VALUES('{title_val}');",
-                                      endsWith="sqlite>",tee=appLog)
-        target.runCommand(f"SELECT * from {xTable};", expectedContents=[f"{title_val}"],
-                                      endsWith="sqlite>",tee=appLog)
-        target.runCommand(".exit",tee=appLog)
+        sqlite_test(".tables", expectedContents=[f"{xTable}"])
+        sqlite_test(f"INSERT INTO {xTable}(title) VALUES('{title_val}');")
+        sqlite_test(f"SELECT * from {xTable};", expectedContents=[f"{title_val}"])
         printAndLog(
             f"Test[insert_record]: The value {title_val} has been successfully inserted into {xTable} table!",
             doPrint=False,tee=getSetting('appLog'))
@@ -61,31 +67,20 @@ def deploymentTest(target):
     def update_record(xTable=tableName, title_val=foodstuff):
         printAndLog(f"Test[update_record]: Update the first record in the table {xTable}  - value {title_val}.",
                     doPrint=False,tee=getSetting('appLog'))
-        target.runCommand(f"{sqlite_bin} {xDb}", expectedContents=["SQLite version", ".help"],
-                                      endsWith="sqlite>",tee=appLog)
-        target.runCommand(".tables", expectedContents=[f"{xTable}"], endsWith="sqlite>",tee=appLog)
-        target.runCommand(f"SELECT * from {xTable};", expectedContents='Pancakes', endsWith="sqlite>",tee=appLog)
-
-        target.runCommand(f"UPDATE {xTable} SET title='{title_val}' WHERE title ='Pancakes';",
-                                      endsWith="sqlite>",tee=appLog)
-        target.runCommand(f"SELECT * from {xTable};", expectedContents=[f"{title_val}"],
-                                      endsWith="sqlite>",tee=appLog)
-        target.runCommand(".exit",tee=appLog)
+        sqlite_test(".tables", expectedContents=[f"{xTable}"])
+        sqlite_test(f"SELECT * from {xTable};", expectedContents='Pancakes')
+        sqlite_test(f"UPDATE {xTable} SET title='{title_val}' WHERE title ='Pancakes';")
+        sqlite_test(f"SELECT * from {xTable};", expectedContents=[f"{title_val}"])
         printAndLog(f"Test[update_record]: The first record has been successfully updated - value {title_val}.",
                     doPrint=False,tee=getSetting('appLog'))
         return
 
     def delete_record(xTable=tableName, title_val=foodstuff):
         printAndLog(f"Test[delete_record]: Delete {title_val} from the {xTable} table.", doPrint=False,tee=getSetting('appLog'))
-        target.runCommand(f"{sqlite_bin} {xDb}", expectedContents=["SQLite version", ".help"],
-                                      endsWith="sqlite>",tee=appLog)
-        target.runCommand(".tables", expectedContents=[f"{xTable}"], endsWith="sqlite>",tee=appLog)
-        target.runCommand(f"SELECT * from {xTable};", expectedContents=[f"{title_val}"],
-                                      endsWith="sqlite>",tee=appLog)
-        target.runCommand(f"DELETE FROM {xTable} WHERE title='{title_val}';",
-                                      endsWith="sqlite>",tee=appLog)
-        target.runCommand(f"SELECT * from {xTable};", expectedContents=[], endsWith="sqlite>",tee=appLog)
-        target.runCommand(".exit",tee=appLog)
+        sqlite_test(".tables", expectedContents=[f"{xTable}"])
+        sqlite_test(f"SELECT * from {xTable};", expectedContents=[f"{title_val}"])
+        sqlite_test(f"DELETE FROM {xTable} WHERE title='{title_val}';")
+        sqlite_test(f"SELECT * from {xTable};", expectedContents=[])
         printAndLog(
             f"Test[delete_record]: The value {title_val} has been successfully deleted from the {xTable} table!",
             doPrint=False,tee=getSetting('appLog'))
@@ -93,18 +88,15 @@ def deploymentTest(target):
 
     def drop_table(xTable=tableName):
         printAndLog(f"Test[drop_table]: Drop {xTable} table", doPrint=False,tee=getSetting('appLog'))
-        target.runCommand(f"{sqlite_bin} {xDb}", expectedContents=["SQLite version", ".help"],
-                                      endsWith="sqlite>",tee=appLog)
-        retCommand = \
-            target.runCommand(".tables", expectedContents=[f"{xTable}"], endsWith="sqlite>", shutdownOnError=False,
-                              suppressErrors=True,tee=appLog)
+        retCommand = sqlite_test(".tables",
+                                expectedContents=[f"{xTable}"],
+                                shutdownOnError=False,
+                                suppressErrors=True)
         if (not retCommand[0]):
-            target.runCommand(".exit",tee=appLog)
             printAndLog(f"Test[drop_table]: Invalid input parameter table {xTable}. Provide valid table name.", doPrint=False)
         else:
-            target.runCommand(f"DROP TABLE IF EXISTS {xTable};", endsWith="sqlite>",tee=appLog)
-            target.runCommand(".tables", expectedContents=[], endsWith="sqlite>",tee=appLog)
-            target.runCommand(".exit",tee=appLog)
+            sqlite_test(f"DROP TABLE IF EXISTS {xTable};")
+            sqlite_test(".tables", expectedContents=[])
             printAndLog(f"Test[drop_table]: The {xTable} table has been dropped successfully!", doPrint=False,tee=getSetting('appLog'))
         return
 

--- a/fett/apps/unix/voting.py
+++ b/fett/apps/unix/voting.py
@@ -5,6 +5,7 @@ This is executed after loading the app on the target to execute this app
 
 from fett.base.utils.misc import *
 from fett.apps.unix.webserver import curlTest
+from fett.apps.unix.database import sqliteCmd
 import string, secrets, crypt
 import json
 
@@ -13,11 +14,7 @@ import json
 def clear_voter_table(target, dbfile):
     appLog = getSetting('appLog')
     sqlite   = "/usr/bin/sqlite"
-    target.runCommand(f"{sqlite} {dbfile}", expectedContents=["SQLite version", ".help"],
-                      erroneousContents=["Error:","near","error"], endsWith="sqlite>",tee=appLog)
-    target.runCommand("DELETE FROM voter;",
-                      endsWith="sqlite>", erroneousContents=["Error:", "near", "error"],tee=appLog)
-    target.runCommand(".exit",tee=appLog)
+    sqliteCmd(target, sqlite, dbfile, "DELETE FROM voter;", tee=appLog)
 
 @decorate.debugWrap
 @decorate.timeWrap
@@ -36,7 +33,7 @@ def add_official(target, dbfile):
     # Insert the record. The database will always be empty at this point,
     # so we give the official ID 0
     insert = f"INSERT INTO electionofficial (id, username, hash) VALUES (0, '{officialName}', '{passHash}');"
-    target.runCommand(f"{sqlite} {dbfile} \"{insert}\"", erroneousContents=["Error:","near","error"] ,tee=appLog)
+    sqliteCmd(target, sqlite, dbfile, insert, tee=appLog)
 
     printAndLog(f"Added election official with username '{officialName}' and password '{password}'")
 


### PR DESCRIPTION
- There's no reason to be driving `sqlite` interactively
- use `mksalt` rather than a fixed salt