### PR TITLE
Replace bridge with 1:1 NAT + fix SQS message IPs

### DIFF
--- a/ci/configs.py
+++ b/ci/configs.py
@@ -16,7 +16,7 @@ commonDefaults = {
     ('openConsole',('No',)),
     ('useCustomOsImage',('No',)),
     ('useCustomProcessor',('No',)),
-    ('awsJumpBoxIp',('172.31.30.56',))
+    ('productionTargetIp',('172.31.30.56',))
 }
 
 unixDefaults = commonDefaults.union({

--- a/config.ini
+++ b/config.ini
@@ -51,9 +51,8 @@ userPasswordHash = $6$xcnc07LxM26Xq$VBAn8.ZfCzEf5MEpftSsCndDaxfPs5gXWjdrvrHcSA6O
 # Output of crypt(3) in SHA-512 mode with user's password as input
 rootUserAccess = No
 # If 'Yes', gives user root access via passwordless su on Debian and FreeBSD.
-awsJumpBoxIp = 172.31.30.56
-# If target is AWS, this sets the IP address of the jump box running on the
-# same subnet as the F1 instance that will be able to communicate with the fpga
+productionTargetIp = 172.31.34.147
+# IP address on AWS to bind the FPGA to via a 1:1 NAT
 
 #--------------------------------------------------------------------------------
 [applications]

--- a/fett.py
+++ b/fett.py
@@ -123,8 +123,8 @@ def main (xArgs):
         aws.sendSQS(getSetting('prodSqsQueueTX'), logAndExit, 'success', 
                     getSetting('prodJobId'), f"{getSetting('prodJobId')}-DEPLOY",
                     reason='fett-target-production-deployment',
-                    hostIp=getSetting('awsIpHost'),
-                    fpgaIp=getSetting('awsIpTarget')
+                    hostIp=aws.getInstanceIp(logAndExit),
+                    fpgaIp=getSetting('productionTargetIp')
                     )
         printAndLog("Sent deployment message to the SQS queue.")
 

--- a/fett/base/utils/aws.py
+++ b/fett/base/utils/aws.py
@@ -15,6 +15,16 @@ def getInstanceId (exitFunc):
     except Exception as exc:
         exitFunc(message=f"Failed to obtain the instance ID.",exc=exc)
 
+def getInstanceIp (exitFunc):
+    try:
+        import urllib.request
+    except Exception as exc:
+        exitFunc(message=f"Failed to <import urllib.request>.",exc=exc)
+
+    try:
+        return urllib.request.urlopen('http://169.254.169.254/latest/meta-data/local-ipv4').read().decode()
+    except Exception as exc:
+        exitFunc(message=f"Failed to obtain the instance IP.",exc=exc)
 
 def sendSQS (urlQueue, exitFunc, status, jobId, nodeId, reason='fett', hostIp='None', fpgaIp='None'):
 
@@ -122,4 +132,3 @@ def pollPortalQueueIndefinitely (urlQueue, exitFunc):
 
         time.sleep(60)            
 
-    

--- a/fett/base/utils/configData.json
+++ b/fett/base/utils/configData.json
@@ -101,8 +101,8 @@
             "type": "boolean"
         },
         {
-            "name": "awsJumpBoxIp",
-            "type": "string"
+            "name": "productionTargetIp",
+            "type": "ipAddress"
         }
     ],
 

--- a/fett/base/utils/misc.py
+++ b/fett/base/utils/misc.py
@@ -66,8 +66,8 @@ def exitFett (exitCode):
         aws.sendSQS(inExit_GetSetting('prodSqsQueueTX'), inExit_logAndExit, jobStatus, 
                     inExit_GetSetting('prodJobId'), f"{inExit_GetSetting('prodJobId')}-TERM",
                     reason='fett-target-production-termination',
-                    hostIp=inExit_GetSetting('awsIpHost'),
-                    fpgaIp=inExit_GetSetting('awsIpTarget')
+                    hostIp=aws.getInstanceIp(inExit_logAndExit),
+                    fpgaIp=inExit_GetSetting('productionTargetIp')
                     )
         printAndLog("Sent termination message to the SQS queue.")       
 

--- a/fett/base/utils/productionTemplate.json
+++ b/fett/base/utils/productionTemplate.json
@@ -13,5 +13,5 @@
     "userPasswordHash" : "COND-REQUIRED-SETTING",
     "rootUserAccess" : "No",
     "buildApps" : "No",
-    "awsJumpBoxIp" : "REQUIRED-SETTING"
+    "productionTargetIp" : "REQUIRED-SETTING"
 }

--- a/fett/base/utils/setupEnv.json
+++ b/fett/base/utils/setupEnv.json
@@ -92,16 +92,6 @@
             "val" : "8e:6b:35:04:00:00"
         },
         {
-            "name" : "awsBridgeAdaptorMacAddress",
-            "type" : "macAddress",
-            "val" : "02:5d:2c:f8:00:00"
-        },
-        {
-            "name" : "awsBridgeAdaptorIp",
-            "type" : "ipAddress",
-            "val" : "172.16.0.3"
-        },
-        {
             "name" : "awsNetMaskTarget",
             "type" : "ipAddress",
             "val" : "255.255.255.0"


### PR DESCRIPTION
This PR makes the FPGA available to the EC2 subnet the F1 is running on by placing it behind a 1:1 NAT.  To accomplish this, AWS users will have to add an additional private IP to their F1 instance's network interface, then set `productionTargetIp` to match this new IP.   FETT will handle the rest.  The FPGA will be reachable at `productionTargetIp`.  

This PR also corrects the `instance-ip` and `fpga-ip` fields of SQS messages to match expectations.  

I tested this PR on AWS in the following configurations:

* Debian with valid `productionTargetIp`
* Debian with invalid `productionTargetIp`
* FreeRTOS with valid `productionTargetIp`
* FreeRTOS with invalid `productionTargetIp`

Closes #456 #451 #200 