### PR TITLE
Fixing list nesting in aws.py

### DIFF
--- a/fett/target/aws.py
+++ b/fett/target/aws.py
@@ -270,7 +270,9 @@ def configTapAdaptor():
         'create' : [
             ['ip', 'tuntap', 'add', 'mode', 'tap', 'dev', tapAdaptor, 'user', getpass.getuser()]
         ],
-        'disableIpv6' : ['sysctl', '-w', 'net.ipv6.conf.' + tapAdaptor + '.disable_ipv6=1'],
+        'disableIpv6' : [
+			['sysctl', '-w', 'net.ipv6.conf.' + tapAdaptor + '.disable_ipv6=1']
+		],
         'natSetup' : [
             # Enable ipv4 forwarding
             ['sysctl', '-w', 'net.ipv4.ip_forward=1'],


### PR DESCRIPTION
Small bug in aws.py causes the environment setup to fail on first run, as a result of it expecting a nested list. 