### PR TITLE
Reducing Expected FreeBSD Boot Time

### DIFF
--- a/fett/target/common.py
+++ b/fett/target/common.py
@@ -201,7 +201,7 @@ class commonTarget():
             elif (isEqSetting('target','qemu')):
                 timeout = 120
             elif (isEqSetting('target', 'aws')):
-                timeout = 450
+                timeout = 480
             else:
                 self.shutdownAndExit(f"start: Timeout is not recorded for target=<{getSetting('target')}>.",overwriteShutdown=False,exitCode=EXIT.Implementation)
             self.stopShowingTime = showElapsedTime (getSetting('trash'),estimatedTime=timeout,stdout=sys.stdout)


### PR DESCRIPTION
The expected boot time for FreeBSD has been reduced from 9 min to 7.5 min - I have made 5 runs, with completion times in 7:11 (2), 7:12 (2), 7:14. Tell me if this is too close.

~L