### PR TITLE
Increase MIT Boot Time

### DIFF
--- a/fett/target/common.py
+++ b/fett/target/common.py
@@ -161,7 +161,7 @@ class commonTarget():
                 if isEqSetting('pvAWS', 'firesim'):
                     timeout = 240
                 elif isEqSetting('pvAWS', 'connectal'):
-                    timeout = 480
+                    timeout = 510
                 else:
                     self.shutdownAndExit(f"start: Unrecognized AWS PV <{getSetting('pvAWS')}>.", overwriteShutdown=False, exitCode=EXIT.Dev_Bug)
             else:


### PR DESCRIPTION
On master, 7/1/20 I experienced a time of 7:41/8:00 at boot. On develop, I experienced 7:17/8:00. As this seems variable, one might consider increasing the time. 