### PR TITLE
FreeBSD: Don't overwrite root's .cshrc on AWS

### DIFF
--- a/fett/target/common.py
+++ b/fett/target/common.py
@@ -229,9 +229,11 @@ class commonTarget():
                 else:
                     self.runCommand ("root",endsWith=tempPrompt)
 
-            self.runCommand("echo \"fettPrompt> \" > promptText.txt",endsWith=tempPrompt) #this is to avoid having the prompt in the set prompt command
-            self.runCommand(f"echo \'set prompt = \"fettPrompt> \"\' > .cshrc",endsWith=tempPrompt)
-            self.runCommand("set prompt = \"`cat promptText.txt`\"")
+            if not isEqSetting('target', 'aws'):
+                self.runCommand("echo \"fettPrompt> \" > promptText.txt",endsWith=tempPrompt) #this is to avoid having the prompt in the set prompt command
+                self.runCommand(f"echo \'set prompt = \"fettPrompt> \"\' > .cshrc",endsWith=tempPrompt)
+                self.runCommand("set prompt = \"`cat promptText.txt`\"")
+                self.runCommand("rm promptText.txt")
 
             printAndLog (f"start: Activating ethernet and setting system time...")
         else:
@@ -422,7 +424,10 @@ class commonTarget():
                 return ":~\$"
         elif (isEqSetting('osImage','FreeBSD')):
             if (self.isCurrentUserRoot):
-                return "fettPrompt>"
+                if isEqSetting('target', 'aws'):
+                    return ":~ #"
+                else:
+                    return "fettPrompt>"
             else:
                 return ":~ \$"
         elif (isEqSetting('osImage','busybox')):
@@ -438,7 +443,10 @@ class commonTarget():
         if (isEqSetting('osImage','debian')):
             return [":~#", ":~\$"]
         elif (isEqSetting('osImage','FreeBSD')):
-            return ["fettPrompt>", ":~ \$"]
+            if isEqSetting('target', 'aws'):
+                return [":~ #", ":~ \$"]
+            else:
+                return ["fettPrompt>", ":~ \$"]
         elif (isEqSetting('osImage','busybox')):
             return ["~ #", "\$"]
         else:


### PR DESCRIPTION
This provides a minimal fix for #564, by disabling overwriting `/root/.cshrc` on AWS. The choice to overwrite the file in the first place dates back to testgen. We needed to store things in `/root`, but were running out of space on FPGA, so we mounted a `tmpfs` on that path. This meant that `/root/.cshrc` did not exist. I believe there were issues checking for the default prompt (which was just `#`), so we had to set it manually. This is not necessary on AWS, since running out of space is no longer an issue.

Fixing this on other platforms would not be too difficult, but it would involve rebuilding the FreeBSD images and possibly making a few more changes on the FETT-Target side, and it seems like AWS is the platform where this really matters.