### PR TITLE
Unix target support for PPAC CWE tests

### DIFF
--- a/fett/cwesEvaluation/compat.py
+++ b/fett/cwesEvaluation/compat.py
@@ -20,8 +20,9 @@ class testgenTargetCompatabilityLayer:
             self.testsPars["SPOOFING_IP"] = getSettingDict("PPAC", "spoofingIP")
             self.testsPars["nAllowedInteractions"] = getSettingDict("PPAC", "test_nAllowedInteractions")
             self.testsPars["nAllowedAuthAttempts"] = getSettingDict("PPAC", "test_nAllowedAuthAttempts")
-            self.testsPars['TESTGEN_TEST_PART'] = getSetting("currentTest")[2]
             self.certsDir = os.path.join(getSetting('buildDir'),'lib_PPAC')
+            if isEqSetting('osImage', 'FreeRTOS'):
+                self.testsPars['TESTGEN_TEST_PART'] = getSetting("currentTest")[2]
         if doesSettingExist("resourceManagement"):
             self.testsPars["nResourceLimit"] = getSettingDict("resourceManagement", "test_nResourceLimit")
 


### PR DESCRIPTION
This PR adds Unix support for the PPAC CWE tests.  It's a tiny PR because most of the work was already merged in #688.  The code has been tested on AWS and produces the expected results on all but test number 294 (ticket #690).  The results for the remaining tests were:

```
(Info)~   ----------------------------------------------------------------------------------
(Info)~  |   TEST   | Score  |                            Notes                             |
(Info)~   ----------------------------------------------------------------------------------
(Info)~  | TEST-257 | V-HIGH |                          p01:V-HIGH                          |
(Info)~  |----------|--------|--------------------------------------------------------------|
(Info)~  | TEST-259 |  N/A   |                     Covered by TEST-257                      |
(Info)~  |----------|--------|--------------------------------------------------------------|
(Info)~  | TEST-284 | V-HIGH |           p01:NONE, p02:NONE, p03:V-HIGH, p04:HIGH           |
(Info)~  |----------|--------|--------------------------------------------------------------|
(Info)~  | TEST-287 | V-HIGH |              p01:V-HIGH, p02:V-HIGH, p03:V-HIGH              |
(Info)~  |----------|--------|--------------------------------------------------------------|
(Info)~  | TEST-288 | V-HIGH |      p01:NONE, p02:NONE, p03:MED, p04:HIGH, p05:V-HIGH       |
(Info)~  |----------|--------|--------------------------------------------------------------|
(Info)~  | TEST-289 | V-HIGH |              p01:V-LOW, p02:V-HIGH, p03:V-HIGH               |
(Info)~  |----------|--------|--------------------------------------------------------------|
(Info)~  | TEST-290 |  N/A   |                     Covered by TEST-294                      |
(Info)~  |----------|--------|--------------------------------------------------------------|
(Info)~  | TEST-301 |  N/A   |              Not Implemented -- Protocol Level               |
(Info)~  |----------|--------|--------------------------------------------------------------|
(Info)~  | TEST-307 | V-HIGH |          p01:V-LOW, p02:HIGH, p03:NONE, p04:V-HIGH           |
(Info)~  |----------|--------|--------------------------------------------------------------|
(Info)~  | TEST-384 | V-HIGH |                          p01:V-HIGH                          |
(Info)~  |----------|--------|--------------------------------------------------------------|
(Info)~  | TEST-521 | V-HIGH |         p01:V-HIGH, p02:V-HIGH, p03:NONE, p04:V-HIGH         |
(Info)~  |----------|--------|--------------------------------------------------------------|
(Info)~  | TEST-799 | V-HIGH | p01:V-HIGH, p02:LOW, p03:V-LOW, p04:NONE, p05:NONE, p06:NONE |
(Info)~   ----------------------------------------------------------------------------------
(Info)~  aws shut down successfully!
(Info)~  checkValidScores: Scores were successfully validated.
(Info)~  End of FETT! [Exit code 0:Success]
```