### PR TITLE
Increasing Timeout on `scp` Calls

### DIFF
--- a/fett/target/common.py
+++ b/fett/target/common.py
@@ -751,7 +751,7 @@ class commonTarget():
 
     @decorate.debugWrap
     @decorate.timeWrap
-    def runApp (self,sendFiles=False,timeout=30): #executes the app
+    def runApp (self,sendFiles=False,timeout=60): #executes the app
         printAndLog ("runApp: Starting the application stack...")
         if (sendFiles):
             #send any needed files to target


### PR DESCRIPTION
Issues:

This timeouts in `sendFile` were reduced in 65cda4224dff47ddde9d0bb4c459c93062639419 This caused two timeouts for `scpProcess.expect()` to be too short and cause tests to fail on MIT Unix and GFE FreeBSD. 

Fixed this by individually doubling each of these timeouts that caused issues.

Tests: 

- Tested 20+ instances of MIT Unix with this branch, in the same manner of testing that produced the bug noted in #721. 100% succeeded.
- Tested 8 instances of GFE FreeBSD on this branch, 100% success after 21f6de62009dea623dd47654bc70c9675b4b85b1, as opposed to 100% failure before (n=8), and 100% failure on `develop` as well (n=12+).
- Tested 6 runs of all instances on `develop` and assured that all other instances work, and only MIT Unix and GFE FreeBSD present symptoms.

Closes #721.

