### PR TITLE
Add bluespec_p1 QEMU support

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -21,7 +21,7 @@ sourceVariant = default
 target = qemu
 # [ qemu | fpga | aws ]
 processor = chisel_p1
-# [chisel_p1, bluespec_p2, chisel_p2]
+# [bluespec_p1, chisel_p1, bluespec_p2, chisel_p2]
 osImage = FreeRTOS
 # [ debian | FreeRTOS | FreeBSD | busybox(limited) ]
 FreeRTOSUseRAMDisk = No

--- a/fett/base/config.py
+++ b/fett/base/config.py
@@ -53,7 +53,7 @@ def loadConfiguration(configFile):
         loadSecurityEvaluationConfiguration(xConfig,configData)
 
     # Get the XLEN and processor flavor
-    if (getSetting('processor') in ['chisel_p1']):
+    if (getSetting('processor') in ['chisel_p1', 'bluespec_p1']):
         setSetting('xlen',32)
     elif (getSetting('processor') in ['chisel_p2', 'bluespec_p2']):
         setSetting('xlen',64)
@@ -61,7 +61,7 @@ def loadConfiguration(configFile):
         logAndExit(f"Failed to determine xlen from <{getSetting('processor')}>.",exitCode=EXIT.Dev_Bug)
     if (getSetting('processor') in ['chisel_p1', 'chisel_p2']):
         setSetting('procFlavor', 'chisel')
-    elif (getSetting('processor') in ['bluespec_p2']):
+    elif (getSetting('processor') in ['bluespec_p1', 'bluespec_p2']):
         setSetting('procFlavor', 'bluespec')
     else:
         logAndExit(f"Failed to determine the processor flavor <chisel or bluespec>.",exitCode=EXIT.Dev_Bug)

--- a/fett/base/utils/configData.json
+++ b/fett/base/utils/configData.json
@@ -29,7 +29,7 @@
         {
             "name" : "processor",
             "type" : "string",
-            "choices" : [ "chisel_p1", "bluespec_p2", "chisel_p2" ]
+            "choices" : [ "bluespec_p1", "chisel_p1", "bluespec_p2", "chisel_p2" ]
         },
         {
             "name" : "osImage",

--- a/fett/base/utils/setupEnv.json
+++ b/fett/base/utils/setupEnv.json
@@ -156,6 +156,9 @@
                     "chisel_p1" : {
                         "FreeRTOS" : "firesim"
                     },
+                    "bluespec_p1" : {
+                        "FreeRTOS" : "notOnAWS"
+                    },
                     "chisel_p2" : {
                         "debian" : "firesim",
                         "FreeBSD" : "notOnAWS",


### PR DESCRIPTION
As far as I could tell by looking at FETT and testgen, properly setting `xlen` and `procFlavor` (as well as adding modifying a couple JSON files) was all that was needed to add QEMU support for the `bluespec_p1`.  However, I'm not as familiar with the processor selection code, so it's possible I missed something.  All CWE tests with QEMU support scored as expected.

Closes #744 