### PR TITLE
Update BOF CWE constraints to better reflect CWE descriptions

### DIFF
--- a/fett/cwesEvaluation/tests/bufferErrors/BufferErrors.cfr
+++ b/fett/cwesEvaluation/tests/bufferErrors/BufferErrors.cfr
@@ -59,14 +59,14 @@ BufferErrors_Test : BufferErrors_Weakness ?
     [ CWE_121 <=> ( Location_Stack && Access_Write ) ]
     [ CWE_122 <=> ( Location_Heap  && Access_Write ) ]
     [ CWE_123 <=> ( Access_Write ) ]
-    [ CWE_124 <=> ( Boundary_Above && Access_Write ) ]
+    [ CWE_124 <=> ( Boundary_Below && Access_Write ) ]
     [ CWE_125 <=> ( Access_Read ) ]
     [ CWE_126 <=> ( Boundary_Above && Access_Read ) ]
     [ CWE_127 <=> ( Boundary_Below && Access_Read ) ]
-    [ CWE_129 <=> ( BufferIndexScheme_PointerArithmetic ) ]
+    [ CWE_129 <=> ( BufferIndexScheme_IndexArray ) ]
     [ CWE_786 <=> ( Boundary_Below ) ]
-    [ CWE_787 ]
+    [ CWE_787 <=> ( Access_Write) ]
     [ CWE_788 <=> ( Boundary_Above ) ]
-    [ CWE_823 <=> ( BufferIndexScheme_IndexArray ) ]
+    [ CWE_823 <=> ( BufferIndexScheme_PointerArithmetic ) ]
 // End of BufferErrors
 


### PR DESCRIPTION
This PR corrects some minor inconsistencies between the CWE constraints in the buffer errors tool, and the CWE descriptions themselves.  Specifically:

* CWE-124 is "Buffer Underwrite ('Buffer Underflow')", but the tool had the constraint `[ CWE_124 <=> ( Boundary_Above && Access_Write ) ]`, meaning it was testing buffer overflows (via `Boundary_Above`).  I changed `Boundary_Above` to` Boundary_Below` to test underflows instead.

* CWE-129 is "Improper Validation of Array Index", but the tool had the constraint `[ CWE_129 <=> ( BufferIndexScheme_PointerArithmetic ) ]`, meaning it was testing an improper index into the array via pointer arithmetic.  However, all of the examples in the CWE definition from MITRE use array indexing, not pointer arithmetic, so I changed the constraint to `[ CWE_129 <=> (BufferIndexScheme_IndexArray) ]` to generate tests with array indexing rather than pointer arithmetic.  I realize pointer arithmetic and array indexing are equivalent in C, but the CWE description seems to make a distinction.

* CWE-787 is "Out-of-bounds Write", but the tool has the constraint `[CWE_787 ]`, meaning that all tests satisfied CWE-787 even if they do only reading and no writing whatsoever.  I changed the constraint to `[ CWE_787 <=> ( Access_Write ) ]`, meaning the test must actually write out of bounds to satisfy the CWE constraint.

* CWE-823 is "Use of Out-of-range Pointer Offset", but the tool has the constraint `[ CWE_823 <=> ( BufferIndexScheme_IndexArray ) ]`.  I think this was swapped with CWE-129 and I changed it to `[ CWE_823 <=> (BufferIndexScheme_PointerArithmetic) ]` to generate tests using pointer indexing rather than array indexing.

 These are all minor, which leads me to believe they were just little mistakes:

* CWE-124 was a typo
* CWE-129 and CWE-823 were accidentally swapped
* CWE-787 was just forgotten when filling in the constraints