### PR TITLE
Trap SIGSEGV in debian buffer errors tool

### DIFF
--- a/fett/cwesEvaluation/bufferErrors/count.py
+++ b/fett/cwesEvaluation/bufferErrors/count.py
@@ -23,12 +23,12 @@ CWE_680_INT_OVERFLOW_LOOKFOR = [
         ]
 
 def triage(filepath,lookfor):
-    testRan = False
     if not filepath.is_file():
         logAndExit(f"<bufferErrors.count.triage> <{filepath}> is not a file",
                    exitCode=EXIT.Files_and_paths)
     for (symbol, indicators) in lookfor:
         log = ftOpenFile(filepath, 'r')
+        testRan = False
         for line in log:
             if '<BufferErrors Start>' in line:
                 testRan = True

--- a/fett/cwesEvaluation/bufferErrors/vulClassTester.py
+++ b/fett/cwesEvaluation/bufferErrors/vulClassTester.py
@@ -3,6 +3,7 @@
 This file has the custom bufferError methods to run tests on qemu|fpga.
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # """
 
+from fett.base.utils.misc import *
 from fett.cwesEvaluation.compat import testgenTargetCompatibilityLayer
 
 class vulClassTester(testgenTargetCompatibilityLayer):
@@ -12,4 +13,15 @@ class vulClassTester(testgenTargetCompatibilityLayer):
         return
 
     def executeTest(self, binTest):
-        return self.typCommand(f"./{binTest}")
+        if isEqSetting("osImage", "debian"):
+            # Run test, and if it returns 11, then echo "Segmentation fault".
+            # This is needed because the debian buffer errors tests catch
+            # SIGSEGV to prevent the kernel from printing debug info that can
+            # interleave with test output.  A side effect of catching SIGSEGV
+            # is that the normal "Segmentation fault" message is not printed,
+            # so we must print it as part of the run command.
+            return self.typCommand(f"./{binTest} ; "
+                                   "[ $? -eq 11 ] && "
+                                   "echo 'Segmentation fault'")
+        else:
+            return self.typCommand(f"./{binTest}")


### PR DESCRIPTION
Enjoy your Thanksgiving holiday weekend and don't look at this until after it has passed.

Closes #869

This change registers a signal handler for SIGSEGV in the debian buffer
error tests to prevent interleaving of OS debug messages with test
output.  The signal handler causes the test to exit with return code 11
(the signal number for SIGSEGV) on a segmentation fault, which fett then
detects and augments the test output with the string "Segmentation
fault" so that the test is properly scored as TRAPPED.