### PR TITLE
VCU118 Debian Networking Fixes

### DIFF
--- a/fett/target/vcu118.py
+++ b/fett/target/vcu118.py
@@ -692,6 +692,7 @@ def resetEthAdaptor ():
             printAndLog("Enabling NAT on main adaptor.")
             sudoShellCommand(['iptables','-t', 'nat','-A','POSTROUTING',
                 '-o',mainAdaptorName,'-j','MASQUERADE'])
+            sudoShellCommand(['iptables', '-P', 'FORWARD', 'ACCEPT'])
 
         #get the name and check configuration if this is the first time called
         if (not doesSettingExist('ethAdaptor')):


### PR DESCRIPTION
This fixes the setup of the default route on the Debian target on VCU118, and adds appropriate `iptables` routes to enable network access from the VCU118 to the outside world (mainly by pulling them in from the `tap` adaptor code for QEMU, but the rules are slightly different).