### PR TITLE
Detect and emit errors for unsatisfiable error models

### DIFF
--- a/fett/cwesEvaluation/bufferErrors/generateTests/generateTests.py
+++ b/fett/cwesEvaluation/bufferErrors/generateTests/generateTests.py
@@ -63,6 +63,10 @@ def generateTests(outdir):
             printAndLog(f"<generateTests> Caching instances to <{instancePath}>")
             safeDumpJsonFile(enumeratedFM, instancePath)
         printAndLog("<generateTests> Done generating instances")
+    if not enumeratedFM:
+        logAndExit(f'<generateTests> Error model <{modelPath}> contains '
+                   'unsatisfiable constraints.',
+                   exitCode=EXIT.Configuration)
     instances = [BofInstance(model, x) for x in enumeratedFM]
     heapSize = parseBytes(getSettingDict('bufferErrors', 'heapSize'))
     stackSize = parseBytes(getSettingDict('bufferErrors', 'stackSize'))


### PR DESCRIPTION
Closes #977.

This PR adds a check for unsatisfiable custom error models so FETT doesn't crash with an unhandled exception like in #976.

I tested this PR on QEMU/VCU118/AWS with GFE processors across FreeRTOS/Debian/FreeBSD.  I also tested with unsatisfiable error models to verify this fixes the crash.