### PR TITLE
INJ tests building and running with bare metal compiler

### DIFF
--- a/fett/cwesEvaluation/build.py
+++ b/fett/cwesEvaluation/build.py
@@ -58,10 +58,6 @@ def buildCwesEvaluation():
 
         fillerCfile = os.path.join(getSetting('repoDir'),'fett','cwesEvaluation','utils','fillerMainFreeRTOS.c')
 
-    if (isEqSetting('binarySource','LMCO') and isEqSetting('osImage','debian') and ('injection' in getSetting("vulClasses"))):
-        warnAndLog(f"<injection> tests will be skipped. Please check ticket #963 for more details.")
-        getSetting("vulClasses").remove('injection')
-
     # Copy tests over
     enabledCwesEvaluations = defaultdict(list)
     isThereAnythingToRun = False
@@ -182,6 +178,10 @@ def buildCwesEvaluation():
                                 'utils',
                                 'defaultEnvUnix.mk'),
                     vulClassDir)
+            if vulClass == "injection":
+                # Copy unix injection helpers over
+                cp(sourcesDir, vulClassDir, "inj_unix_helpers.*")
+
 
         #Set the list of enabled tests
         setSetting('enabledCwesEvaluations', enabledCwesEvaluations)

--- a/fett/cwesEvaluation/injection/Makefile.xcompileDir
+++ b/fett/cwesEvaluation/injection/Makefile.xcompileDir
@@ -1,0 +1,20 @@
+# this makefile is for cross compiling injection C files in a directory for emulation
+
+include defaultEnvUnix.mk
+
+TARGETS := $(patsubst ./%.c, ./%.riscv, $(wildcard ./test_inj_*.c))
+
+all: $(TARGETS)
+
+# Compiling
+%o: %.c
+	$(CC) -c -o $@ $(CFLAGS) $<
+
+# Linking
+%.riscv: inj_unix_helpers.o %.o
+	$(LD) -o $@ $(LDFLAGS) $^
+
+clean:
+	rm -f *.o *.riscv
+
+.PHONY: clean all

--- a/fett/cwesEvaluation/injection/setupEnv.json
+++ b/fett/cwesEvaluation/injection/setupEnv.json
@@ -5,6 +5,11 @@
 
     "injection" : [
         {
+            "name" : "classSpecificMake",
+            "type" : "bool",
+            "val"  : 1
+        },
+        {
             "name" : "testsInfo",
             "type" : "dict",
             "val" : {

--- a/fett/cwesEvaluation/injection/sources/inj_unix_helpers.c
+++ b/fett/cwesEvaluation/injection/sources/inj_unix_helpers.c
@@ -1,0 +1,61 @@
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+// Size of buffer to use when reading from stdin
+#define BUF_SIZE 32
+
+#include "inj_unix_helpers.h"
+
+// Read a line from stdin, storing the line in `line`.  Strips the '\n' from
+// the string.
+static void read_line(char line[BUF_SIZE]) {
+    // Use read syscall rather than getline so the tests build on a bare metal
+    // compiler
+    for (size_t i = 0; i < BUF_SIZE; ++i) {
+        // Read one character at a time
+        ssize_t bytes = read(0, line + i, sizeof(char));
+        if (bytes != sizeof(char)) {
+            printf("<INVALID>\n");
+            printf("Failed to read from stdin.\n");
+            exit(0);
+        }
+        switch (line[i]) {
+            case '\n':
+                // Replace newline with null terminator and return
+                line[i] = '\0';
+                return;
+            case '\0':
+                printf("<INVALID>\n");
+                printf("Unexpected null terminator.\n");
+                exit(0);
+            default:
+                // Keep reading
+                break;
+        }
+    }
+    printf("<INVALID>\n");
+    printf("Buffer full before reading newline.\n");
+    exit(0);
+}
+
+int read_int() {
+    char line[BUF_SIZE];
+    read_line(line);
+    int value = atoi(line);
+    return value;
+}
+
+uintptr_t read_uintptr_t() {
+    char line[BUF_SIZE];
+    read_line(line);
+    uintptr_t value = (uintptr_t) strtoull(line, NULL, 0);
+    if (value == ULLONG_MAX) {
+        printf("<INVALID>\n");
+        printf("Failed to convert string to integer\n");
+        exit(0);
+    }
+    return value;
+}

--- a/fett/cwesEvaluation/injection/sources/inj_unix_helpers.h
+++ b/fett/cwesEvaluation/injection/sources/inj_unix_helpers.h
@@ -1,0 +1,14 @@
+#ifndef INJ_UNIX_HELPERS_H_
+#define INJ_UNIX_HELPERS_H_
+
+#include <stdint.h>
+
+// Read and return an int from stdin.  Must be on its own line, terminated with
+// a newline.
+int read_int();
+
+// Read and return a uintptr_t from stdin.  Must be on its own line, terminated
+// with a newline.
+uintptr_t read_uintptr_t();
+
+#endif  // INJ_UNIX_HELPERS_H_

--- a/fett/cwesEvaluation/injection/sources/test_inj_2.c
+++ b/fett/cwesEvaluation/injection/sources/test_inj_2.c
@@ -8,6 +8,7 @@
 #include <task.h>
 #else // !testgenOnFreeRTOS
 #include <stdlib.h>
+#include "inj_unix_helpers.h"
 #endif
 
 // Number of elements in untrusted1.
@@ -248,26 +249,12 @@ static void rtos_test() {
     // Don't free untrusted2 or trusted as they are overlapping memory regions.
 }
 
-#else
-
-// Read an int from stdin
-static int read_value() {
-    char* line = NULL;
-    size_t len = 0;
-    if (getline(&line, &len, stdin) == -1) {
-        printf("<INVALID>\n");
-        printf("Failed to read from stdin\n");
-        free(line);
-        exit(0);
-    }
-    int value = atoi(line);
-    free(line);
-    return value;
-}
+#endif  // testgenOnFreeRTOS
+#ifdef testgenOnDebian
 
 static bool get_buffer_increment(int64_t* untrusted, int64_t untrusted_size) {
     // Read index
-    int index = read_value();
+    int index = read_int();
 
     // Check for overflows, but not underflows to metadata.
     if (index >= untrusted_size) {
@@ -290,7 +277,7 @@ static bool get_buffer_increment(int64_t* untrusted, int64_t untrusted_size) {
     }
 
     // Read and apply increment
-    int64_t increment = (int64_t) read_value();
+    int64_t increment = (int64_t) read_int();
     untrusted[index] += increment;
 
     return true;
@@ -361,7 +348,7 @@ static void debian_test() {
 
     // Don't free untrusted2 or trusted as they are overlapping memory regions.
 }
-#endif
+#endif  // testgenOnDebian
 
 int main(void) {
     printf("<BEGIN_INJECTION_TEST>\n");

--- a/fett/cwesEvaluation/injection/sources/test_inj_3.c
+++ b/fett/cwesEvaluation/injection/sources/test_inj_3.c
@@ -6,8 +6,8 @@
 #include <message_buffer.h>
 #include <task.h>
 #else  // !testgenOnFreeRTOS
-#include <limits.h>
 #include <stdlib.h>
+#include "inj_unix_helpers.h"
 #endif  // !testgenOnFreeRTOS
 
 typedef union {
@@ -97,21 +97,7 @@ void stdin_test(void) {
 
     // Take a number over stdin and store in data.num (thus overwriting data.fn
     // without triggering a const error).
-    char* line = NULL;
-    size_t len = 0;
-    if (getline(&line, &len, stdin) == -1) {
-        printf("<INVALID>\n");
-        printf("Failed to read from stdin\n");
-        free(line);
-        return;
-    }
-    data.num = (uintptr_t) strtoull(line, NULL, 0);
-    free(line);
-    if (data.num == 0 || data.num == ULLONG_MAX) {
-        printf("<INVALID>\n");
-        printf("Failed to convert string to integer\n");
-        return;
-    }
+    data.num = read_uintptr_t();
 
     // Execute injected function pointer.
     data.fn();


### PR DESCRIPTION
Closes #963.

This PR:

* Replaces calls to `getline` with syscall `read(0...)` so INJ tests compile on bare metal.
* Replaces calls to `sleep` with syscall `nanosleep` so INJ tests compile on bare metal.
* Uses syscalls `read` and `nanosleep` in all test versions (not just for LMCO) so we don't have to maintain two separate versions of the tests.
* Creates a library of INJ helpers for reading integers from stdin on Unix and refactors the tests to all use it.
* Re-enables INJ tests on LMCO P2.
* Cleans up the tests a bit.

I tested this on:
* GFE processors running FreeRTOS/Debian/FreeBSD on AWS/QEMU/VCU118
* LCMO P2 on AWS
* GCC and Clang (as the tests can be sensitive to compiler choice).