### PR TITLE
Add support for custom clang and sysroot

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -166,6 +166,14 @@ useCustomMakefile = No
 # Use a custom Makefile. This makefile will be copied to the tests directory as 'Makefile', and be executed by 'make'.
 pathToCustomMakefile = /path/to/Makefile
 # The path to the custom makefile. 
+useCustomClang = No
+# Use a custom Clang binary.
+pathToCustomClang = /path/to/clang
+# The path to the custom Clang binary (passed to make as CLANG).
+useCustomSysroot = No
+# Use a custom sysroot.
+pathToCustomSysroot = /path/to/sysroot
+# The path to the custom sysroot directory (passed to make SYSROOT).
 #--------------------------------------------------------------------------------
 
 #--------------------------------------------------------------------------------

--- a/fett/base/utils/configData.json
+++ b/fett/base/utils/configData.json
@@ -275,6 +275,24 @@
             "name" : "pathToCustomMakefile",
             "type" : "filePath",
             "condition" : "useCustomMakefile"
+        },
+        {
+            "name" : "useCustomClang",
+            "type" : "bool"
+        },
+        {
+            "name" : "pathToCustomClang",
+            "type" : "filePath",
+            "condition" : "useCustomClang"
+        },
+        {
+            "name" : "useCustomSysroot",
+            "type" : "bool"
+        },
+        {
+            "name" : "pathToCustomSysroot",
+            "type" : "dirPath",
+            "condition" : "useCustomSysroot"
         }
     ],
 

--- a/fett/target/build.py
+++ b/fett/target/build.py
@@ -449,12 +449,18 @@ def crossCompileUnix(directory,extraString=''):
     envLinux.append(f"LINKER={getSetting('linker').upper()}")
     envLinux.append(f"BIN_SOURCE={getSetting('binarySource').replace('-','_')}")
     envLinux.append(f"SOURCE_VARIANT={getSetting('sourceVariant')}")
+    if (isEnabled('useCustomCompiling') and
+        isEnabledDict('customizedCompiling','useCustomClang')
+        ):
+        envLinux.append(f"CLANG={getSettingDict('customizedCompiling','pathToCustomClang')}")
+    if (isEnabled('useCustomCompiling') and
+        isEnabledDict('customizedCompiling','useCustomSysroot')
+        ):
+        envLinux.append(f"SYSROOT={getSettingDict('customizedCompiling','pathToCustomSysroot')}")
     logging.debug(f"going to make using {envLinux}")
     if (isEqSetting('binarySource','SRI-Cambridge')):
-        if (isEnabled('useCustomCompiling') and
-            isEnabledDict('customizedCompiling','useCustomMakefile')
-	    ):
-            warnAndLog("cross-compile: Will not use the docker toolchain while <useCustomMakefile> is enabled.")
+        if (isEnabled('useCustomCompiling')):
+            warnAndLog("cross-compile: Will not use the docker toolchain while <useCustomCompiling> is enabled.")
             dockerToolchainImage = None
         else:
             dockerToolchainImage = 'cambridge-toolchain'

--- a/fett/target/utils/defaultEnvUnix.mk
+++ b/fett/target/utils/defaultEnvUnix.mk
@@ -46,7 +46,9 @@ ifeq ($(BIN_SOURCE),SRI_Cambridge)
 else
 	SYSROOT_FreeBSD := $(FETT_GFE_FREEBSD_SYSROOT)
 endif
-CC_CLANG := clang -target ${PREFIX_$(OS_IMAGE)} --sysroot=${SYSROOT_$(OS_IMAGE)}
+CLANG ?= clang
+SYSROOT ?= $(SYSROOT_$(OS_IMAGE))
+CC_CLANG := $(CLANG) -target ${PREFIX_$(OS_IMAGE)} --sysroot=$(SYSROOT)
 
 LD_GCC_GCC := $(CC_GCC)
 LD_CLANG_GCC := $(LD_GCC_GCC)


### PR DESCRIPTION
This adds three new variables to the [customizedCompiling] section:
useCustomClang, pathToCustomClang, useCustomSysroot,
pathToCustomSysroot.  When enabled, the value of pathToCustomClang is
passed to make as CLANG and the value of pathToCustomSysroot is passed
as SYSROOT and they are used in preference to other values in defaultEnvUnix.mk.

While here, expand disabling of docker for SRI-Cambridge builds to
any time useCustomCompiling is enabled.

This change is sufficient to let me compile and run all the tests for CheriABI and run them on CheriBSD without resorting to custom Makefiles (which no longer scale due to divergence between different test categories).