### PR TITLE
Don't use an ssh agent

### DIFF
--- a/fett/target/common.py
+++ b/fett/target/common.py
@@ -1262,7 +1262,7 @@ class commonTarget():
             self.enableSshOnRoot()
 
         portPart = '' if (not self.sshHostPort) else f" -p {self.sshHostPort}"
-        sshCommand = f"ssh{portPart} {userName}@{self.ipTarget}"
+        sshCommand = f"env -u SSH_AUTH_SOCK ssh{portPart} {userName}@{self.ipTarget}"
         sshPassword = self.rootPassword  if (userName=='root') else self.userPassword
         #Need to clear the ECDSA key first in case it is not the first time
         if (not self.sshECDSAkeyWasUpdated):


### PR DESCRIPTION
If the user has too many keys in their agent they may use up all their
login attempts before reaching the the working one.