### PR TITLE
Add sigtrap to the expected keywords for test-468

### DIFF
--- a/fett/cwesEvaluation/resourceManagement/customCweScores/test_468.py
+++ b/fett/cwesEvaluation/resourceManagement/customCweScores/test_468.py
@@ -33,6 +33,8 @@ def test_468 (logLines):
             partsScores[1] = SCORES.FAIL
         if (doesKeywordExist(partsLines[2],"<WRONG_OFFSET>")):
             partsScores[2] = SCORES.HIGH
+        elif (doesKeywordExist(partsLines[2], "<GDB-SIGTRAP>")):
+            partsScores[2] = SCORES.HIGH
         else:
             partsScores[2] = SCORES.FAIL
 


### PR DESCRIPTION
Found this behavior on `chisel_p2` while compiling the test using Clang and the new FreeRTOS fork.