### PR TITLE
Hacked Infotainment Server

### DIFF
--- a/besspin/cyberPhys/infotainment-server/.gitignore
+++ b/besspin/cyberPhys/infotainment-server/.gitignore
@@ -1,6 +1,9 @@
 .vscode
 .o
 a.out
+hacked_server
+hacked_server_linux
+hacked_server_freebsd
 infotainment_server
 infotainment_server_linux
 infotainment_server_freebsd

--- a/besspin/cyberPhys/infotainment-server/Makefile
+++ b/besspin/cyberPhys/infotainment-server/Makefile
@@ -5,6 +5,11 @@ SERVER_SRCS =	source/main.c \
 				source/infotainment_utils.c \
 				$(CANLIB)/*.c
 
+HACKED_SRCS =	source/hacked.c \
+				source/hacked_server.c \
+				source/hacked_utils.c \
+				$(CANLIB)/*.c
+
 TEST_SRCS = source/test_client.c \
 			source/infotainment_utils.c \
 			$(CANLIB)/*.c
@@ -16,15 +21,19 @@ ARCH_FLAGS = -march=rv64imafdc -mabi=lp64d
 
 all: native linux freebsd
 
-native: infotainment_server_native test_client_native
+native: infotainment_server_native hacked_server_native test_client_native
 
-linux: infotainment_server_linux test_client_linux
+linux: infotainment_server_linux hacked_server_linux test_client_linux
 
-freebsd: infotainment_server_freebsd test_client_freebsd
+freebsd: infotainment_server_freebsd hacked_server_freebsd test_client_freebsd
 
 infotainment_server_native:
     # uses the local GCC, whatever it is
 	gcc -I$(CANLIB) $(SERVER_SRCS) -o infotainment_server
+
+hacked_server_native:
+    # uses the local GCC, whatever it is
+	gcc -I$(CANLIB) $(HACKED_SRCS) -o hacked_server
 
 test_client_native:
     # uses the local GCC, whatever it is
@@ -33,23 +42,29 @@ test_client_native:
 infotainment_server_linux:
 	$(LINUX_CC) $(ARCH_FLAGS) -I$(CANLIB) $(SERVER_SRCS) -o infotainment_server_linux
 
+hacked_server_linux:
+	$(LINUX_CC) $(ARCH_FLAGS) -I$(CANLIB) $(HACKED_SRCS) -o hacked_server_linux
+
 test_client_linux:
 	$(LINUX_CC) $(ARCH_FLAGS) -I$(CANLIB) $(TEST_SRCS) -o test_client_linux
 	
 infotainment_server_freebsd:
 	$(FREEBSD_CC) $(FREEBSD_FLAGS) $(ARCH_FLAGS) -I$(CANLIB) $(SERVER_SRCS) -o infotainment_server_freebsd
 
+hacked_server_freebsd:
+	$(FREEBSD_CC) $(FREEBSD_FLAGS) $(ARCH_FLAGS) -I$(CANLIB) $(HACKED_SRCS) -o hacked_server_freebsd
+
 test_client_freebsd:
 	$(FREEBSD_CC) $(FREEBSD_FLAGS) $(ARCH_FLAGS) -I$(CANLIB) $(TEST_SRCS) -o test_client_freebsd
 	
 besspin_binaries: linux freebsd
-	cp infotainment_server_linux ../../../BESSPIN-LFS/GFE/appsBinaries/infotainment-server/debian/infotainment_server
-	cp infotainment_server_freebsd ../../../BESSPIN-LFS/GFE/appsBinaries/infotainment-server/FreeBSD/infotainment_server
+	cp infotainment_server_linux hacked_server_linux ../../../BESSPIN-LFS/GFE/appsBinaries/infotainment-server/debian/infotainment_server
+	cp infotainment_server_freebsd hacked_server_freebsd ../../../BESSPIN-LFS/GFE/appsBinaries/infotainment-server/FreeBSD/infotainment_server
 
 clean:
 	@find . -name "*.out" -type f -delete
 	@find . -name "*.asm" -type f -delete
 	@find . -name "*.elf" -type f -delete
-	rm -f infotainment_server* test_client*
+	rm -f infotainment_server* hacked_server* test_client*
 
-.PHONY: infotainment_server test_client infotainment_server_freebsd test_client_freebsd infotainment_server_linux test_client_linux clean
+.PHONY: infotainment_server hacked_server test_client infotainment_server_freebsd hacked_server_freebsd test_client_freebsd infotainment_server_linux hacked_server_linux test_client_linux clean

--- a/besspin/cyberPhys/infotainment-server/source/hacked.c
+++ b/besspin/cyberPhys/infotainment-server/source/hacked.c
@@ -1,0 +1,57 @@
+/**
+ * Hacked Infotainment Server
+ * Copyright (C) 2020-21 Galois, Inc.
+ * @author Daniel M. Zimmerman <dmz@galois.com>
+ * @refine besspin_cyberphys.lando
+ */
+
+#include <signal.h>
+#include "hacked_server.h"
+#include "hacked_utils.h"
+#include "infotainment_debug.h" // no need to hack debug functions
+
+void interrupt_handler(int unused) {
+    debug("interrupt received\n");
+    stop();
+}
+
+// currently, the main function just runs the event loop
+int main(int argc, char** argv) {
+    // interrupt handling
+    struct sigaction action;
+    action.sa_handler = interrupt_handler;
+    action.sa_flags = 0;
+    sigemptyset(&action.sa_mask);
+    sigaction(SIGINT, &action, NULL);
+
+    debug("attempting legitimate infotainment server\n");
+    int result = system("systemctl stop infotainmment-server.service");
+    
+    if (result != 0) {
+        debug("could not kill legitimate infotainmment server, running anyway\n");
+    } else {
+        debug("legitimate infotainment server killed\n");
+    }
+
+    debug("hacked infotainment server starting\n");
+
+    if (argc == 2) {
+        // one argument means an override of the broadcast address
+        set_broadcast_address(argv[1]);
+    }
+
+    if (initialize()) {
+        result = main_loop();
+    } else {
+        error("unable to initialize server\n");
+    }
+
+    if (result == 0) {
+        debug("hacked infotainment server exiting\n");
+    } else
+    {
+        debug("hacked infotainment server reported error %d\n", result);
+    }
+    
+    return result;
+}

--- a/besspin/cyberPhys/infotainment-server/source/hacked_defs.h
+++ b/besspin/cyberPhys/infotainment-server/source/hacked_defs.h
@@ -1,0 +1,104 @@
+/**
+ * Hacked Infotainment Server Types and Constants
+ * Copyright (C) 2020-21 Galois, Inc.
+ * @author Daniel M. Zimmerman <dmz@galois.com>
+ * @refine besspin_cyberphys.lando
+ * 
+ * This is the "hacked" version of the infotainment server; it listens only 
+ * to the hacker kiosk for control commands, and sends GPS positions
+ * back to the hacker kiosk as they are updated on the network. It also 
+ * still responds to network heartbeats, so that it will not be killed by
+ * an overly-aggressive watchdog.
+ */
+
+#ifndef __HACKED_DEFS__
+#define __HACKED_DEFS__
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+// we listen for CAN packets on the receive port
+#define RECEIVE_PORT_CAN 5002
+
+// we also listen for CAN packets from the hacker kiosk
+#define RECEIVE_PORT_KIOSK 5811 // 8 = H, 11 = K
+
+// we send CAN packets to the main CAN network
+#define SEND_PORT_CAN 5002
+
+// we also send CAN packets to the hacker kiosk (for GPS updates)
+#define SEND_PORT_KIOSK 5811
+
+// the minimum volume
+#define MIN_VOLUME 0
+
+// the maximum volume
+#define MAX_VOLUME 31
+
+// the "default" volume
+#define DEFAULT_VOLUME 11
+
+// the default broadcast address (as a string)
+#define DEFAULT_BROADCAST_ADDRESS "255.255.255.255"
+
+// the states of the state machines; note that the current volume and
+// selected station are not reflected here but are stored in variables.
+// also note that ensuring distinct values requires these definitions to
+// be coupled together, so the ordering of these declarations matters.
+
+typedef enum { VOLUME_OFF,
+               VOLUME_UNKNOWN,
+               VOLUME_IN_RANGE,
+               VOLUME_MAX } volume_state;
+typedef enum { MUSIC_UNKNOWN = VOLUME_MAX + 1,
+               MUSIC_PAUSED,
+               MUSIC_PLAYING } music_state;
+typedef enum { STATION_UNKNOWN = MUSIC_PLAYING + 1,
+               STATION_SET } station_state;
+// note: if the position doesn't need to be relayed, we can get rid of
+// this part of the state machine and state storage and just deal with
+// music state
+typedef enum { POSITION_UNKNOWN = STATION_SET + 1,
+               POSITION_SET } position_state;
+typedef enum { START = POSITION_SET + 1,
+               RUNNING,
+               STOP } top_level_state;
+
+typedef struct infotainment_state_t {
+    top_level_state T;
+    volume_state V;
+    uint8_t volume;
+    music_state M;
+    station_state S;
+    uint8_t station;
+    position_state P;
+    float pos_x;
+    float pos_y;
+    float pos_z;
+    float pos_r;
+} infotainment_state;
+
+// constants for interpreting CAN messages; these are subject to 
+// change until the CAN message spec is finalized
+
+#define BUTTON_STATION_1 0x01
+#define BUTTON_STATION_2 0x02
+#define BUTTON_STATION_3 0x03
+#define BUTTON_VOLUME_DOWN 0x10
+#define BUTTON_VOLUME_UP 0x11
+
+#define PAUSE_PLAY_MASK 1 // 0b1
+#define STATION_MASK 6 // 0b110
+#define VOLUME_MASK 248 // 0b11111000
+
+// music state decode functions (takes the payload of a music state CAN packet)
+#define play(c) (c & PAUSE_PLAY_MASK)
+#define station(c) ((c & STATION_MASK) >> 1)
+#define volume(c) ((c & VOLUME_MASK) >> 3)
+
+// music state construction function (takes an infotainment_state_t)
+#define music_state_packet(s) ((s.volume << 3) | (s.station << 1) | (1 & (s.M == MUSIC_PLAYING)))
+// no need for bitmasks with the positions because they're just floats
+
+#endif // __HACKED_DEFS_H__

--- a/besspin/cyberPhys/infotainment-server/source/hacked_server.c
+++ b/besspin/cyberPhys/infotainment-server/source/hacked_server.c
@@ -1,0 +1,363 @@
+/**
+ * Hacked Infotainment Server
+ * Copyright (C) 2020-21 Galois, Inc.
+ * @author Daniel M. Zimmerman <dmz@galois.com>
+ * @refine besspin_cyberphys.lando
+ * 
+ * This is the "hacked" version of the infotainment server; it listens only 
+ * to the hacker kiosk for control commands, and sends GPS positions
+ * back to the hacker kiosk as they are updated on the network. It also 
+ * still responds to network heartbeats, so that it will not be killed by
+ * an overly-aggressive watchdog.
+ */
+
+// general includes
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <arpa/inet.h> 
+#include <netinet/in.h>
+#include <sys/types.h> 
+#include <sys/select.h>
+#include <sys/socket.h> 
+
+#include "canlib.h"
+#include "canspecs.h"
+
+#include "hacked_defs.h"
+#include "hacked_server.h"
+#include "hacked_utils.h"
+#include "infotainment_debug.h" // no need to hack debug functions
+
+// initialize global state variables
+infotainment_state the_state = { .T = START };
+
+bool initialize(void) {
+    if (the_state.T == RUNNING) {
+        debug("initialize called on running server\n");
+        return false;
+    }
+
+    // initialize the state; we don't know much initially but
+    // we'll set the various fields to sane values
+    the_state.V = VOLUME_UNKNOWN;
+    the_state.M = MUSIC_UNKNOWN;
+    the_state.S = STATION_UNKNOWN;
+    the_state.P = POSITION_UNKNOWN;
+    the_state.volume = 0;
+    the_state.station = 0;
+    the_state.pos_x = 0.0f;
+    the_state.pos_y = 0.0f;
+    the_state.pos_z = 0.0f;
+    the_state.pos_r = 0.0f;
+    the_state.T = RUNNING;
+
+    return true;
+}
+
+int main_loop(void) {
+    debug("socket numbers are %d (CAN) and %d (Kiosk)\n", 
+          udp_socket(RECEIVE_PORT_CAN), udp_socket(RECEIVE_PORT_KIOSK));
+    
+    while (the_state.T == RUNNING) {
+        // refresh the sockets in case one of them died
+        int can_socketfd = udp_socket(RECEIVE_PORT_CAN);
+        int kiosk_socketfd = udp_socket(RECEIVE_PORT_KIOSK);
+
+        fd_set sockets;
+        FD_ZERO(&sockets);
+        FD_SET(can_socketfd, &sockets);
+        FD_SET(kiosk_socketfd, &sockets);
+
+        int nfds = ((can_socketfd > kiosk_socketfd) ? can_socketfd : kiosk_socketfd) + 1; 
+        if (select(nfds, &sockets, (fd_set *) 0, (fd_set *) 0, 0) >= 0) {
+            if (FD_ISSET(can_socketfd, &sockets)) {
+                debug("CAN frame available on CAN socket\n");
+                receive_from_socket(can_socketfd, RECEIVE_PORT_CAN);
+            }
+            if (FD_ISSET(kiosk_socketfd, &sockets)) {
+                debug("CAN frame available on kiosk socket\n");
+                receive_from_socket(kiosk_socketfd, RECEIVE_PORT_KIOSK);
+            }
+        }
+    }
+
+    debug("stop signal received, cleaning up\n");
+    // close the UDP sockets in an orderly fashion since we're
+    // no longer listening
+    close(udp_socket(RECEIVE_PORT_CAN));
+    close(udp_socket(RECEIVE_PORT_KIOSK));
+
+    return 0;
+}
+
+void receive_from_socket(int socketfd, int port) {
+    // initialize socket address and buffer data structures
+    struct sockaddr_in broadcast_address;
+    struct sockaddr_in receive_address;
+    socklen_t receive_address_len;
+    uint8_t message[MESSAGE_BUFFER_SIZE];
+    can_frame *frame;
+
+    // receive a packet
+    memset(&message, 0, MESSAGE_BUFFER_SIZE);
+    frame = receive_frame(socketfd, port, message, MESSAGE_BUFFER_SIZE,
+                          &receive_address, &receive_address_len);
+
+    // attempt to decode the frame and see if it is for us
+    if (frame == NULL)
+    {
+        return;
+    }
+    else if (!is_relevant(frame->can_id))
+    {
+        debug("received CAN frame with irrelevant ID %x\n", frame->can_id);
+        return;
+    }
+
+    // change our state based on the received CAN frame
+
+    debug("processing CAN frame with ID %x\n", frame->can_id);
+    bool position_updated = false;
+    switch (frame->can_id)
+    {
+        case CAN_ID_CAR_X:
+        case CAN_ID_CAR_Y:
+        case CAN_ID_CAR_Z:
+        case CAN_ID_CAR_R:
+            if (port == RECEIVE_PORT_CAN) {
+                position_updated = update_position(frame);
+            } else {
+                debug("position update frame from kiosk ignored\n");
+            }
+            break;
+
+        case CAN_ID_BUTTON_PRESSED:
+            if (port == RECEIVE_PORT_KIOSK) {
+                handle_button_press(frame);
+            } else {
+                debug("button press from CAN ignored\n");
+            }
+            break;
+
+        case CAN_ID_HEARTBEAT_REQ:
+            if (port == RECEIVE_PORT_CAN) {
+                broadcast_heartbeat_ack(frame);
+            } else {
+                debug("heartbeat req from kiosk ignored\n");
+            }
+            break;
+    }
+
+    // broadcast the new state; we always broadcast the current music state
+    // if a button was pressed (on the kiosk), and we also broadcast any 
+    // position state that has been updated
+    if (frame->can_id == CAN_ID_BUTTON_PRESSED && port == RECEIVE_PORT_KIOSK)
+    {
+        broadcast_music_state();
+    }
+    if (position_updated)
+    {
+        broadcast_position(frame->can_id);
+    }
+}
+
+bool is_relevant(canid_t can_id) {
+    bool result = false;
+
+    switch (can_id) {
+        case CAN_ID_BUTTON_PRESSED:
+        case CAN_ID_CAR_X:
+        case CAN_ID_CAR_Y:
+        case CAN_ID_CAR_Z:
+        case CAN_ID_CAR_R:
+        case CAN_ID_HEARTBEAT_REQ:
+            result = true;
+    }
+
+    return result;
+}
+
+bool update_position(can_frame *frame) {
+    // make sure the frame is an appropriate type
+    assert(frame->can_id == CAN_ID_CAR_X || frame->can_id == CAN_ID_CAR_Y ||
+           frame->can_id == CAN_ID_CAR_Z || frame->can_id == CAN_ID_CAR_R);
+
+    // copy the payload into a float and fix its byte order; this is done
+    // instead of a simple cast to (float *) for alignment reasons
+    float position;
+    memcpy(&position, &frame->data[0], sizeof(float));
+    position = iu_ntohf(position);
+
+    float *old_position = position_for_dimension(&the_state, frame->can_id);    
+    char dimension = char_for_dimension(frame->can_id);
+    bool changed = false;
+
+    if (*old_position == position) {
+        debug("%c position update (%f) results in no change\n", 
+              dimension, position);
+    } else {
+        *old_position = position;
+        changed = true;
+        debug("updated %c position to %f\n", dimension, *old_position);
+    }
+
+    return changed;
+}
+
+bool handle_button_press(can_frame *frame) {
+    // make sure the frame is an appropriate type
+    assert(frame->can_id == CAN_ID_BUTTON_PRESSED);
+
+    // interpret the payload as a single byte
+    unsigned char *payload = (unsigned char *) frame->data;
+    bool changed = false;
+
+    switch (*payload) {
+        case BUTTON_STATION_1:
+            debug("station 1 set\n");
+            changed = set_station(1);
+            break;
+        case BUTTON_STATION_2:
+            debug("station 2 set\n");
+            changed = set_station(2);
+            break;
+        case BUTTON_STATION_3:
+            debug("station 3 set\n");
+            changed = set_station(3);
+            break;
+        case BUTTON_VOLUME_DOWN:
+            debug("volume down pressed\n");
+            changed = decrease_volume();
+            break;
+        case BUTTON_VOLUME_UP:
+            debug("volume up pressed\n");
+            changed = increase_volume();
+            break;
+        default:
+            debug("invalid button press (%d) received, ignoring\n", 
+                  *payload);
+    }
+
+    return changed;
+}
+
+bool set_station(uint8_t station) {
+    bool changed = !(the_state.station == station);
+    the_state.M = MUSIC_PLAYING;
+    the_state.S = STATION_SET;
+    the_state.station = station;
+    return changed;
+}
+
+bool increase_volume() {
+    bool changed = false;
+    switch (the_state.V) {
+        case VOLUME_UNKNOWN:
+            changed = true;
+            the_state.V = VOLUME_IN_RANGE;
+            the_state.volume = DEFAULT_VOLUME;
+            break;
+        case VOLUME_IN_RANGE:
+        case VOLUME_OFF:
+            changed = !(the_state.volume == MAX_VOLUME);
+            the_state.volume = the_state.volume + 1;
+            if (the_state.volume == MAX_VOLUME) {
+                the_state.V = VOLUME_MAX;
+            } else {
+                the_state.V = VOLUME_IN_RANGE;
+            }
+            break;
+        default:
+            break;
+    }
+    return changed;
+}
+
+bool decrease_volume() {
+    bool changed = false;
+    switch (the_state.V) {
+        case VOLUME_UNKNOWN:
+            changed = true;
+            the_state.V = VOLUME_IN_RANGE;
+            the_state.volume = DEFAULT_VOLUME;
+            break;
+        case VOLUME_IN_RANGE:
+        case VOLUME_MAX:
+            changed = !(the_state.volume == MIN_VOLUME);
+            the_state.volume = the_state.volume - 1;
+            if (the_state.volume == MIN_VOLUME) {
+                the_state.V = VOLUME_OFF;
+            } else {
+                the_state.V = VOLUME_IN_RANGE;
+            }
+            break;
+        default:
+            break;
+    }
+    return changed;
+}
+
+void broadcast_music_state() {
+    if (the_state.M == MUSIC_UNKNOWN || the_state.S == STATION_UNKNOWN ||
+        the_state.V == VOLUME_UNKNOWN) {
+        debug("warning: broadcasting music state with default values\n");
+    }
+
+    uint8_t data = music_state_packet(the_state);
+    can_frame frame = { .can_id = CAN_ID_INFOTAINMENT_STATE,
+                        .can_dlc = BYTE_LENGTH_INFOTAINMENT_STATE };
+    frame.data[0] = data;
+
+    debug("broadasting music state frame: playing %d, station %d, volume %d\n",
+          the_state.M == MUSIC_PLAYING, the_state.station, the_state.volume);
+    broadcast_frame(RECEIVE_PORT_CAN, SEND_PORT_CAN, &frame);
+}
+
+void broadcast_position(canid_t can_id) {
+    // make sure the ID is appropriate
+    assert(can_id == CAN_ID_CAR_X || can_id == CAN_ID_CAR_Y ||
+           can_id == CAN_ID_CAR_Z || can_id == CAN_ID_CAR_R);
+
+    float *position = position_for_dimension(&the_state, can_id);
+    char dimension = char_for_dimension(can_id);
+
+    // BYTE_LENGTH_CAR_X is the same as Y and Z
+    can_frame frame = { .can_id = can_id, .can_dlc = BYTE_LENGTH_CAR_X };
+    float network_position = iu_htonf(*position);
+    memcpy(&frame.data[0], &network_position, sizeof(float));
+
+    debug("broadcasting new %c position: %f\n", dimension, *position);
+    // must broadcast both to infotainment thin client and to kiosk
+    broadcast_frame(RECEIVE_PORT_KIOSK, SEND_PORT_KIOSK, &frame);
+    broadcast_frame(RECEIVE_PORT_CAN, SEND_PORT_CAN, &frame);
+}
+
+void broadcast_heartbeat_ack(can_frame *frame) {
+    assert(frame->can_id == CAN_ID_HEARTBEAT_REQ);
+
+    can_frame ack = { .can_id = CAN_ID_HEARTBEAT_ACK, 
+                      .can_dlc = BYTE_LENGTH_HEARTBEAT_ACK };
+
+    // copy our local address into the first 4 bytes of the response
+    memcpy(&ack.data[0], &get_local_address()->s_addr, sizeof(uint32_t));
+
+    // then copy the data, which must be in the right byte order already,
+    // from the heartbeat request
+    memcpy(&ack.data[4], &frame->data[0], sizeof(uint32_t));
+
+    // but we still need the right byte order to output debug info
+    uint32_t *heartbeat_id = (uint32_t *) &ack.data[0];
+    debug("broadcasting response to heartbeat request %ju\n", 
+          (uintmax_t) ntohl(*heartbeat_id));
+    broadcast_frame(RECEIVE_PORT_CAN, SEND_PORT_CAN, &ack);
+}
+
+void stop(void) {
+    debug("stopping state machine after current iteration\n");
+    the_state.T = STOP;
+}

--- a/besspin/cyberPhys/infotainment-server/source/hacked_server.h
+++ b/besspin/cyberPhys/infotainment-server/source/hacked_server.h
@@ -1,0 +1,113 @@
+/**
+ * Hacked Infotainment Server
+ * Copyright (C) 2020-21 Galois, Inc.
+ * @author Daniel M. Zimmerman <dmz@galois.com>
+ * @refine besspin_cyberphys.lando
+ * 
+ * This is the "hacked" version of the infotainment server; it listens only 
+ * to the hacker kiosk for control commands, and sends GPS positions
+ * back to the hacker kiosk as they are updated on the network. It also 
+ * still responds to network heartbeats, so that it will not be killed by
+ * an overly-aggressive watchdog.
+ */
+
+#ifndef __INFOTAINMENT_SERVER_H__
+#define __INFOTAINMENT_SERVER_H__
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "canlib.h"
+#include "hacked_defs.h"
+
+/**
+ * The size of the message receive buffer.
+ */
+#define MESSAGE_BUFFER_SIZE 128
+
+/**
+ * Initialize the state machine for the infotainment server.
+ * @return true if initialization is successful, false otherwise.
+ */
+bool initialize(void);
+
+/**
+ * The main event loop.
+ * @return 0 if terminated cleanly; currently, there is no other way
+ * to terminate without the program dying.
+ */
+int main_loop(void);
+
+/**
+ * @param socketfd The socket file descriptor to receive from.
+ * @param port The port that file descriptor is listening to (used for self-
+ * loop detection on messages).
+ */
+void receive_from_socket(int socketfd, int port);
+
+/**
+ * @param can_id The CAN ID of a message.
+ * @return true if the specified CAN ID is relevant to the infotainment
+ * server for further processing, false otherwise.
+ */
+bool is_relevant(canid_t can_id);
+
+/**
+ * Update our position based on the specified position CAN frame.
+ * @param can_id The CAN frame. Must have ID CAN_ID_CAR_X, CAN_ID_CAR_Y, 
+ * or CAN_ID_CAR_Z.
+ * @return true if the position was changed, false otherwise.
+ */
+bool update_position(can_frame *frame);
+
+/**
+ * Update our state based on the specified button press CAN frame.
+ * @param frame The CAN frame. Must have ID CAN_ID_BUTTON_PRESSED.
+ * @return true if the state was changed, false otherwise.
+ */
+bool handle_button_press(can_frame *frame);
+
+/**
+ * State change for setting the music station.
+ * @param station The new station number.
+ * @return true if the station was changed, false otherwise.
+ */
+bool set_station(uint8_t station);
+
+/**
+ * State change for increasing the volume.
+ * @return true if the volume changed, false otherwise.
+ */
+bool increase_volume();
+
+/**
+ * State change for decreasing the volume.
+ * @return true if the volume changed, false otherwise.
+ */
+bool decrease_volume();
+
+/**
+ * Broadcast a packet with the current music state (station, volume, playing).
+ */
+void broadcast_music_state();
+
+/**
+ * Broadcast a position update for the appropriate dimension based on the 
+ * CAN ID.
+ * @param can_id The CAN ID. Must be CAN_ID_CAR_X, CAN_ID_CAR_Y, or 
+ * CAN_ID_CAR_Z.
+ */
+void broadcast_position(canid_t can_id);
+
+/**
+ * Broadcast an acknoweledgement to the specified heartbeat request.
+ * @param frame The request CAN frame. Must have ID CAN_ID_HEARTBEAT_REQ.
+ */
+void broadcast_heartbeat_ack(can_frame *frame);
+
+/**
+ * Stop the server (typically from a Ctrl-C handler).
+ */
+void stop(void);
+
+#endif // __INFOTAINMENT_SERVER_H__

--- a/besspin/cyberPhys/infotainment-server/source/hacked_utils.c
+++ b/besspin/cyberPhys/infotainment-server/source/hacked_utils.c
@@ -1,0 +1,321 @@
+/**
+ * Hacked Infotainment Server Utility Functions
+ * Copyright (C) 2020-21 Galois, Inc.
+ * @author Daniel M. Zimmerman <dmz@galois.com>
+ * @refine besspin_cyberphys.lando
+ * 
+ * This is the "hacked" version of the infotainment server; it listens only 
+ * to the hacker kiosk for control commands, and sends GPS positions
+ * back to the hacker kiosk as they are updated on the network. It also 
+ * still responds to network heartbeats, so that it will not be killed by
+ * an overly-aggressive watchdog.
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <ifaddrs.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <arpa/inet.h> 
+#include <netinet/in.h>
+#include <sys/types.h> 
+#include <sys/socket.h> 
+
+#include "canlib.h"
+#include "canspecs.h"
+#include "hacked_defs.h"
+#include "hacked_utils.h"
+#include "infotainment_debug.h" // no need to hack debug functions
+
+static char *broadcast_address = DEFAULT_BROADCAST_ADDRESS;
+static struct in_addr local_address = { .s_addr = 0 };
+
+int udp_socket(int listen_port) {
+    static int socketfd[SOCKET_CACHE_SIZE];
+    static int port[SOCKET_CACHE_SIZE];
+    static struct sockaddr_in listen_address;
+
+    // check that one of the sockets is listening on the right port; 
+    // if not, close one of them and create a new one
+    struct sockaddr_in current_address;
+    socklen_t current_len = sizeof(struct sockaddr_in);
+    int index;
+
+    for (index = 0; index < SOCKET_CACHE_SIZE; index++) {
+        if (port[index] == 0 || port[index] == listen_port) {
+            break;
+        }
+    }
+    
+    if (index == SOCKET_CACHE_SIZE) {
+        // if we need to close a socket, close the first one; if we 
+        // really wanted to we could do least-recently-opened, but
+        // it's not worth it here
+        index = 0;
+    }
+
+    if (0 < socketfd[index] && 
+        getsockname(socketfd[index], (struct sockaddr *) &current_address, 
+                    &current_len) == 0) {
+        if (ntohs(current_address.sin_port) != listen_port) {
+            // it's listening on the wrong port, close it
+            debug("closing socket on port %d\n", 
+                  ntohs(current_address.sin_port));
+            close(socketfd[index]);
+            socketfd[index] = -1;
+        } // else we leave the socket alone
+    } else if (0 < socketfd[index]) {
+        // couldn't get socket status, reset it to -1
+        debug("couldn't get socket status for socket %d, errno %d\n", 
+              socketfd[index], errno);
+        socketfd[index] = -1;
+    }
+
+    // create the socket if it doesn't exist or has been closed     
+    if (socketfd[index] <= 0 || 
+        (fcntl(socketfd[index], F_GETFD) == -1 && errno != EBADF)) {
+        debug("creating socket on port %d\n", listen_port);
+
+        if ((socketfd[index] = 
+               socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) == -1) {
+            error("unable to create socket: error %d\n", errno);
+        } 
+        
+        // initialize the listen address
+        memset((char *) &listen_address, 0, sizeof(listen_address));
+        listen_address.sin_family = AF_INET;
+        listen_address.sin_port = htons(listen_port);
+        listen_address.sin_addr.s_addr = htonl(INADDR_ANY);
+
+        // set socket options to receive broadcasts and share address/port
+        if (setsockopt(socketfd[index], SOL_SOCKET, SO_BROADCAST, 
+                       &(int){1}, sizeof(int)) < 0) {
+            error("unable to set broadcast listening mode\n");
+        }
+        if (setsockopt(socketfd[index], SOL_SOCKET, SO_REUSEPORT, 
+                       &(int){1}, sizeof(int)) < 0) {
+            // this is not fatal but does mean a hack that tries to listen
+            // on the same port won't work
+            debug("warning: unable to set port reuse mode\n");
+        }
+
+        // bind the socket to the port
+        if (bind(socketfd[index], 
+                 (struct sockaddr *) &listen_address, 
+                 sizeof(listen_address)) == -1) {
+            error("unable to listen on port %d\n", listen_port);
+        }
+
+        debug("socket created, listening for broadcasts on port %d\n", listen_port);
+    }
+
+    port[index] = listen_port;
+    return socketfd[index];
+}
+
+char char_for_dimension(canid_t dimension_id) {
+    char result = '?';
+
+    switch (dimension_id) {
+        case CAN_ID_CAR_X:
+            result = 'x';
+            break;
+        case CAN_ID_CAR_Y:
+            result = 'y';
+            break;
+        case CAN_ID_CAR_Z:
+            result = 'z';
+            break;
+        case CAN_ID_CAR_R:
+            result = 'r';
+            break;
+        default:
+            error("char_for_dimension called for bad CAN frame type %x\n", dimension_id);
+    }
+
+    return result;
+}
+
+float *position_for_dimension(infotainment_state *the_state, canid_t dimension_id) {
+    float *result = NULL;
+
+    switch (dimension_id) {
+        case CAN_ID_CAR_X:
+            result = &(the_state->pos_x);
+            break;
+        case CAN_ID_CAR_Y:
+            result = &(the_state->pos_y);
+            break;
+        case CAN_ID_CAR_Z:
+            result = &(the_state->pos_z);
+            break;
+        case CAN_ID_CAR_R:
+            result = &(the_state->pos_r);
+            break;
+        default:
+            error("position_for_dimension called for bad CAN frame type %x\n",
+                  dimension_id);
+    }
+    return result;
+}
+
+can_frame *receive_frame(int socketfd, int port, uint8_t *message, int message_len, 
+                         struct sockaddr_in *receive_address, 
+                         socklen_t *receive_address_len) {
+    can_frame *result = NULL;
+
+    *receive_address_len = sizeof(struct sockaddr_in);          // must be initialized
+    int32_t bytes = recvfrom(socketfd, message, message_len, 0, // no flags
+                             (struct sockaddr *)receive_address,
+                             receive_address_len);
+
+    // if the frame came from us, ignore it; we determine this to be the case if
+    // the receive address matches one of our interface addresses _and_ the port
+    // number matches the port number of our socket
+    if (is_our_address(port, receive_address))
+    {
+        debug("received CAN frame from ourselves, ignoring\n");
+        return NULL;
+    }
+    else
+    {
+        debug("received %i bytes from %s\n",
+              bytes, inet_ntoa(receive_address->sin_addr));
+    }
+
+    // decode the packet
+    if (bytes < 0)
+    {
+        debug("CAN frame receive failed\n");
+        return NULL;
+    }
+    else if (bytes == 0)
+    {
+        debug("received empty CAN frame\n");
+        return NULL;
+    }
+    else if (bytes < 5)
+    {
+        debug("received partial CAN frame, ignoring\n");
+        return NULL;
+    }
+
+    result = (can_frame *)message;
+    if (sizeof(can_frame) < bytes)
+    {
+        debug("received (probable) J1939 message, ignoring\n");
+        return NULL;
+    }
+    else if (result->can_dlc != bytes - 5)
+    {
+        debug("received CAN message with invalid length (%d)\n", bytes);
+        return NULL;
+    }
+
+    // adjust the byte order of the CAN ID to host byte order
+    result->can_id = ntohl(result->can_id);
+
+    return result;
+}
+
+void set_broadcast_address(char *address) {
+    debug("setting broadcast address to %s\n", address);
+    broadcast_address = address;
+}
+
+struct in_addr *get_local_address() {
+    return &local_address;
+}
+
+int broadcast_frame(int from_port, int to_port, can_frame *frame) {
+    struct sockaddr_in broadcast_addr;
+    memset(&broadcast_addr, 0, sizeof(struct sockaddr_in));
+    broadcast_addr.sin_family = AF_INET;
+    broadcast_addr.sin_port = htons(to_port);
+    broadcast_addr.sin_addr.s_addr = inet_addr(broadcast_address);
+
+    // copy the CAN frame into the local variable to modify it for
+    // network byte order
+    can_frame frame_to_send;
+    memcpy(&frame_to_send, frame, sizeof(can_frame));
+    frame_to_send.can_id = htonl(frame->can_id);
+
+    debug("sending frame to broadcast address %s:%d\n",
+        inet_ntoa(broadcast_addr.sin_addr), to_port);
+    return sendto(udp_socket(from_port), &frame_to_send, 
+                  5 + frame_to_send.can_dlc, 0, // no flags
+                  (struct sockaddr *) &broadcast_addr, 
+                  sizeof(struct sockaddr_in));
+}
+
+bool is_our_address(int port, struct sockaddr_in *check_address) {
+    bool result = false;
+    struct ifaddrs *addresses, *addr;
+
+    // get all interfaces
+    if (getifaddrs(&addresses) == -1) {
+        error("could not get interface addresses (error %d)\n", errno);
+    }
+
+    // check each address to see whether it matches
+    for (addr = addresses; addr != NULL; addr = addr->ifa_next) {
+        if (addr->ifa_addr == NULL || addr->ifa_addr->sa_family != AF_INET) {
+            // not an IPv4 address
+            continue;
+        }
+        struct sockaddr_in *our_address = (struct sockaddr_in *) addr->ifa_addr;
+        bool match = (our_address->sin_addr.s_addr - 
+                      check_address->sin_addr.s_addr) == 0;
+        if (match && local_address.s_addr == 0) {
+            // our local address hadn't been set yet, but here it is
+            local_address.s_addr = our_address->sin_addr.s_addr;
+            debug("local IP address detected as %s\n", inet_ntoa(local_address));
+        }
+        result = result || match;
+    }
+
+    freeifaddrs(addresses);
+    
+    if (result) {
+        // if an address matched, check the port of the socket
+        struct sockaddr_in socket_addr;
+        socklen_t len = sizeof(struct sockaddr_in);
+        if (getsockname(udp_socket(port), 
+                        (struct sockaddr *) &socket_addr, &len) == -1) {
+            // this isn't fatal, it just means we might receive our own packet
+            debug("couldn't get socket info for local socket\n");
+            result = false;
+        } else {
+            result = (check_address->sin_port == socket_addr.sin_port);
+        }
+    }
+
+    return result;
+}
+
+float iu_ntohf(float val) {
+    union {
+        uint32_t i;
+        float f;
+    } conv;
+
+    conv.f = val;
+    conv.i = ntohl(conv.i);
+
+    return conv.f;
+}
+
+float iu_htonf(float val) {
+    union {
+        uint32_t i;
+        float f;
+    } conv;
+
+    conv.f = val;
+    conv.i = htonl(conv.i);
+
+    return conv.f;
+}

--- a/besspin/cyberPhys/infotainment-server/source/hacked_utils.h
+++ b/besspin/cyberPhys/infotainment-server/source/hacked_utils.h
@@ -1,0 +1,109 @@
+/**
+ * Hacked Infotainment Server Utility Functions
+ * Copyright (C) 2020-21 Galois, Inc.
+ * @author Daniel M. Zimmerman <dmz@galois.com>
+ * @refine besspin_cyberphys.lando
+ * 
+ * This is the "hacked" version of the infotainment server; it listens only 
+ * to the hacker kiosk for control commands, and sends GPS positions
+ * back to the hacker kiosk as they are updated on the network. It also 
+ * still responds to network heartbeats, so that it will not be killed by
+ * an overly-aggressive watchdog.
+ */
+
+#include <unistd.h>
+
+#include "hacked_defs.h"
+
+/**
+ * The number of sockets to cache.
+ */
+#define SOCKET_CACHE_SIZE 2
+
+/**
+ * Get a UDP socket listening on the specified port, creating it if necessary.
+ * This function will cache two sockets before killing one to create a new one.
+ * @param listen_port The port number.
+ * @return 0 if successful, error code if not successful
+ */
+int udp_socket(int listen_port);
+
+/**
+ * Get a character (x, y, z, r) based on the CAN ID for a position dimension.
+ * @param dimension_id The CAN ID for the dimension.
+ * @return the character.
+ */
+char char_for_dimension(canid_t dimension_id);
+
+/** 
+ * Gets a pointer to the position (in the state) based on the CAN ID for a 
+ * position dimension.
+ * @param the_state The state to use.
+ * @param dimension_id The dimension to find.
+ * @return a pointer to the appropriate position float.
+ */
+float *position_for_dimension(infotainment_state *the_state, canid_t dimension_id);
+
+/**
+ * Receives a CAN frame sent to the specified port. In the returned frame, the CAN ID
+ * is in host byte order.
+ * 
+ * @param socketfd The file descriptor on which to receive.
+ * @param port The port that socket is listening on (for self-loop detection).
+ * @param buffer The buffer in which to receive the CAN frame.
+ * @param buffer_len The length of the CAN frame buffer.
+ * @param receive_address The address that the CAN frame came from.
+ * @param receive_address_len The length of the address that the CAN frame came from.
+ * @return a pointer to the resulting CAN frame, or NULL if no CAN frame was received.
+ */
+can_frame *receive_frame(int socketfd, int port, uint8_t *buffer, int buffer_len, 
+                         struct sockaddr_in *receive_address, 
+                         socklen_t *receive_address_len);
+
+/**
+ * Sets the broadcast address to use.
+ * @param address The broadcast address, as a string.
+ */
+void set_broadcast_address(char *address);
+
+/**
+ * @return a pointer to the local address as a struct in_addr.
+ */
+struct in_addr *get_local_address();
+
+/**
+ * Broadcasts a CAN frame to the specified port, on all IPv4 interfaces.
+ * Broadcasts a CAN frame to the specified port, on all IPv4 interfaces. It is assumed
+ * that the CAN ID field in the frame is in host byte order.
+ *
+ * @param from_port The port to broadcast from.
+ * @param to_port The port to broadcast to.
+ * @param frame The CAN frame to broadcast.
+ * @return The number of bytes sent, or an error code, as from canframe_recvfrom. Note
+ * that if more than one broadcast encounters an error, only the lowest error code is
+ * returned.
+ */
+int broadcast_frame(int from_port, int to_port, can_frame *frame);
+
+/**
+ * Checks to see if the specified address is one of the addresses for the
+ * socket created on the specified port.
+ * @param port The port of the socket to check.
+ * @param address The socket address to check.
+ * @return true if the address is one of our addresses, false otherwise.
+ */
+bool is_our_address(int port, struct sockaddr_in *address);
+
+/**
+ * Converts a float from network byte order to local byte order.
+ * @param val The float value to convert.
+ * @return the converted float value.
+ */
+float iu_ntohf(float val);
+
+/**
+ * Converts a float from local byte order to network byte order.
+ * @param val The float value to convert.
+ * @return the converted float value.
+ */
+float iu_htonf(float val);


### PR DESCRIPTION
This branch is the hacked infotainment server. It is mostly the same as the original infotainment server, but modified to listen for packets on two different ports, ignoring all but GPS and heartbeat packets on the main CAN network port and ignoring all but button presses on the special hacker kiosk command and control port. It also broadcasts GPS position updates to the hacker kiosk command and control port in addition to the main CAN network.

Note that the hacker kiosk is meant to communicate with the hacked infotainment server on port 5811 (H = 8, K = 11 in the alphabet), and should be listening on that same port for GPS updates, at least the way the constants are currently defined in the headers.

I have not tested this in the actual environment, but I have tested it listening to thin clients on two different ports and it behaves as I expect it to. So I think it can be merged in, pending the possible need to add functionality as I proposed in #1168.

Closes #1160