### PR TITLE
Quieter Infotainment Servers

### DIFF
--- a/besspin/cyberPhys/infotainment-server/Makefile
+++ b/besspin/cyberPhys/infotainment-server/Makefile
@@ -18,6 +18,8 @@ LINUX_CC = riscv64-unknown-linux-gnu-gcc
 FREEBSD_CC = clang -target riscv64-unknown-freebsd12.1 --sysroot=$(BESSPIN_GFE_FREEBSD_SYSROOT)
 FREEBSD_FLAGS = -Wno-error=sign-compare -mno-relax -fuse-ld=lld
 ARCH_FLAGS = -march=rv64imafdc -mabi=lp64d
+DEBUG := 0
+DEBUG_FLAGS = -DINFOTAINMENT_DEBUG_FLAG=$(DEBUG)
 
 all: native linux freebsd
 
@@ -29,33 +31,33 @@ freebsd: infotainment_server_freebsd hacked_server_freebsd test_client_freebsd
 
 infotainment_server_native:
     # uses the local GCC, whatever it is
-	gcc -I$(CANLIB) $(SERVER_SRCS) -o infotainment_server
+	gcc -I$(CANLIB) $(DEBUG_FLAGS) $(SERVER_SRCS) -o infotainment_server
 
 hacked_server_native:
     # uses the local GCC, whatever it is
-	gcc -I$(CANLIB) $(HACKED_SRCS) -o hacked_server
+	gcc -I$(CANLIB) $(DEBUG_FLAGS) $(HACKED_SRCS) -o hacked_server
 
 test_client_native:
     # uses the local GCC, whatever it is
-	gcc -I$(CANLIB) $(TEST_SRCS) -o test_client
+	gcc -I$(CANLIB) $(DEBUG_FLAGS) $(TEST_SRCS) -o test_client
 
 infotainment_server_linux:
-	$(LINUX_CC) $(ARCH_FLAGS) -I$(CANLIB) $(SERVER_SRCS) -o infotainment_server_linux
+	$(LINUX_CC) $(ARCH_FLAGS) $(DEBUG_FLAGS) -I$(CANLIB) $(SERVER_SRCS) -o infotainment_server_linux
 
 hacked_server_linux:
-	$(LINUX_CC) $(ARCH_FLAGS) -I$(CANLIB) $(HACKED_SRCS) -o hacked_server_linux
+	$(LINUX_CC) $(ARCH_FLAGS) $(DEBUG_FLAGS) -I$(CANLIB) $(HACKED_SRCS) -o hacked_server_linux
 
 test_client_linux:
-	$(LINUX_CC) $(ARCH_FLAGS) -I$(CANLIB) $(TEST_SRCS) -o test_client_linux
+	$(LINUX_CC) $(ARCH_FLAGS) $(DEBUG_FLAGS) -I$(CANLIB) $(TEST_SRCS) -o test_client_linux
 	
 infotainment_server_freebsd:
-	$(FREEBSD_CC) $(FREEBSD_FLAGS) $(ARCH_FLAGS) -I$(CANLIB) $(SERVER_SRCS) -o infotainment_server_freebsd
+	$(FREEBSD_CC) $(FREEBSD_FLAGS) $(ARCH_FLAGS) $(DEBUG_FLAGS) -I$(CANLIB) $(SERVER_SRCS) -o infotainment_server_freebsd
 
 hacked_server_freebsd:
-	$(FREEBSD_CC) $(FREEBSD_FLAGS) $(ARCH_FLAGS) -I$(CANLIB) $(HACKED_SRCS) -o hacked_server_freebsd
+	$(FREEBSD_CC) $(FREEBSD_FLAGS) $(ARCH_FLAGS) $(DEBUG_FLAGS) -I$(CANLIB) $(HACKED_SRCS) -o hacked_server_freebsd
 
 test_client_freebsd:
-	$(FREEBSD_CC) $(FREEBSD_FLAGS) $(ARCH_FLAGS) -I$(CANLIB) $(TEST_SRCS) -o test_client_freebsd
+	$(FREEBSD_CC) $(FREEBSD_FLAGS) $(ARCH_FLAGS) $(DEBUG_FLAGS) -I$(CANLIB) $(TEST_SRCS) -o test_client_freebsd
 	
 besspin_binaries: linux freebsd
 	cp infotainment_server_linux hacked_server_linux ../../../BESSPIN-LFS/GFE/appsBinaries/infotainment-server/debian/infotainment_server

--- a/besspin/cyberPhys/infotainment-server/source/hacked.c
+++ b/besspin/cyberPhys/infotainment-server/source/hacked.c
@@ -24,16 +24,16 @@ int main(int argc, char** argv) {
     sigemptyset(&action.sa_mask);
     sigaction(SIGINT, &action, NULL);
 
-    debug("attempting legitimate infotainment server\n");
+    message("attempting to kill legitimate infotainment server\n");
     int result = system("systemctl stop infotainmment-server.service");
     
     if (result != 0) {
-        debug("could not kill legitimate infotainmment server, running anyway\n");
+        message("could not kill legitimate infotainmment server, running anyway\n");
     } else {
-        debug("legitimate infotainment server killed\n");
+        message("legitimate infotainment server killed\n");
     }
 
-    debug("hacked infotainment server starting\n");
+    message("hacked infotainment server starting\n");
 
     if (argc == 2) {
         // one argument means an override of the broadcast address
@@ -47,10 +47,10 @@ int main(int argc, char** argv) {
     }
 
     if (result == 0) {
-        debug("hacked infotainment server exiting\n");
+        message("hacked infotainment server exiting\n");
     } else
     {
-        debug("hacked infotainment server reported error %d\n", result);
+        message("hacked infotainment server reported error %d\n", result);
     }
     
     return result;

--- a/besspin/cyberPhys/infotainment-server/source/hacked_server.c
+++ b/besspin/cyberPhys/infotainment-server/source/hacked_server.c
@@ -60,8 +60,8 @@ bool initialize(void) {
 }
 
 int main_loop(void) {
-    debug("socket numbers are %d (CAN) and %d (Kiosk)\n", 
-          udp_socket(RECEIVE_PORT_CAN), udp_socket(RECEIVE_PORT_KIOSK));
+    message("socket numbers are %d (CAN) and %d (Kiosk)\n", 
+            udp_socket(RECEIVE_PORT_CAN), udp_socket(RECEIVE_PORT_KIOSK));
     
     while (the_state.T == RUNNING) {
         // refresh the sockets in case one of them died
@@ -86,7 +86,7 @@ int main_loop(void) {
         }
     }
 
-    debug("stop signal received, cleaning up\n");
+    message("stop signal received, cleaning up\n");
     // close the UDP sockets in an orderly fashion since we're
     // no longer listening
     close(udp_socket(RECEIVE_PORT_CAN));
@@ -132,7 +132,7 @@ void receive_from_socket(int socketfd, int port) {
             if (port == RECEIVE_PORT_CAN) {
                 position_updated = update_position(frame);
             } else {
-                debug("position update frame from kiosk ignored\n");
+                message("position update frame from kiosk ignored\n");
             }
             break;
 
@@ -140,7 +140,7 @@ void receive_from_socket(int socketfd, int port) {
             if (port == RECEIVE_PORT_KIOSK) {
                 handle_button_press(frame);
             } else {
-                debug("button press from CAN ignored\n");
+                message("button press from CAN ignored\n");
             }
             break;
 
@@ -148,7 +148,7 @@ void receive_from_socket(int socketfd, int port) {
             if (port == RECEIVE_PORT_CAN) {
                 broadcast_heartbeat_ack(frame);
             } else {
-                debug("heartbeat req from kiosk ignored\n");
+                message("heartbeat req from kiosk ignored\n");
             }
             break;
     }
@@ -203,7 +203,7 @@ bool update_position(can_frame *frame) {
     } else {
         *old_position = position;
         changed = true;
-        debug("updated %c position to %f\n", dimension, *old_position);
+        message("updated %c position to %f\n", dimension, *old_position);
     }
 
     return changed;
@@ -219,28 +219,28 @@ bool handle_button_press(can_frame *frame) {
 
     switch (*payload) {
         case BUTTON_STATION_1:
-            debug("station 1 set\n");
+            message("station 1 set\n");
             changed = set_station(1);
             break;
         case BUTTON_STATION_2:
-            debug("station 2 set\n");
+            message("station 2 set\n");
             changed = set_station(2);
             break;
         case BUTTON_STATION_3:
-            debug("station 3 set\n");
+            message("station 3 set\n");
             changed = set_station(3);
             break;
         case BUTTON_VOLUME_DOWN:
-            debug("volume down pressed\n");
+            message("volume down pressed\n");
             changed = decrease_volume();
             break;
         case BUTTON_VOLUME_UP:
-            debug("volume up pressed\n");
+            message("volume up pressed\n");
             changed = increase_volume();
             break;
         default:
-            debug("invalid button press (%d) received, ignoring\n", 
-                  *payload);
+            message("invalid button press (%d) received, ignoring\n", 
+                    *payload);
     }
 
     return changed;
@@ -313,8 +313,8 @@ void broadcast_music_state() {
                         .can_dlc = BYTE_LENGTH_INFOTAINMENT_STATE };
     frame.data[0] = data;
 
-    debug("broadasting music state frame: playing %d, station %d, volume %d\n",
-          the_state.M == MUSIC_PLAYING, the_state.station, the_state.volume);
+    message("broadasting music state frame: playing %d, station %d, volume %d\n",
+            the_state.M == MUSIC_PLAYING, the_state.station, the_state.volume);
     broadcast_frame(RECEIVE_PORT_CAN, SEND_PORT_CAN, &frame);
 }
 
@@ -331,7 +331,7 @@ void broadcast_position(canid_t can_id) {
     float network_position = iu_htonf(*position);
     memcpy(&frame.data[0], &network_position, sizeof(float));
 
-    debug("broadcasting new %c position: %f\n", dimension, *position);
+    message("broadcasting new %c position: %f\n", dimension, *position);
     // must broadcast both to infotainment thin client and to kiosk
     broadcast_frame(RECEIVE_PORT_KIOSK, SEND_PORT_KIOSK, &frame);
     broadcast_frame(RECEIVE_PORT_CAN, SEND_PORT_CAN, &frame);
@@ -358,6 +358,6 @@ void broadcast_heartbeat_ack(can_frame *frame) {
 }
 
 void stop(void) {
-    debug("stopping state machine after current iteration\n");
+    message("stopping state machine after current iteration\n");
     the_state.T = STOP;
 }

--- a/besspin/cyberPhys/infotainment-server/source/hacked_utils.c
+++ b/besspin/cyberPhys/infotainment-server/source/hacked_utils.c
@@ -62,22 +62,22 @@ int udp_socket(int listen_port) {
                     &current_len) == 0) {
         if (ntohs(current_address.sin_port) != listen_port) {
             // it's listening on the wrong port, close it
-            debug("closing socket on port %d\n", 
-                  ntohs(current_address.sin_port));
+            message("closing socket on port %d\n", 
+                    ntohs(current_address.sin_port));
             close(socketfd[index]);
             socketfd[index] = -1;
         } // else we leave the socket alone
     } else if (0 < socketfd[index]) {
         // couldn't get socket status, reset it to -1
-        debug("couldn't get socket status for socket %d, errno %d\n", 
-              socketfd[index], errno);
+        message("couldn't get socket status for socket %d, errno %d\n", 
+                socketfd[index], errno);
         socketfd[index] = -1;
     }
 
     // create the socket if it doesn't exist or has been closed     
     if (socketfd[index] <= 0 || 
         (fcntl(socketfd[index], F_GETFD) == -1 && errno != EBADF)) {
-        debug("creating socket on port %d\n", listen_port);
+        message("creating socket on port %d\n", listen_port);
 
         if ((socketfd[index] = 
                socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) == -1) {
@@ -99,7 +99,7 @@ int udp_socket(int listen_port) {
                        &(int){1}, sizeof(int)) < 0) {
             // this is not fatal but does mean a hack that tries to listen
             // on the same port won't work
-            debug("warning: unable to set port reuse mode\n");
+            message("warning: unable to set port reuse mode\n");
         }
 
         // bind the socket to the port
@@ -109,7 +109,7 @@ int udp_socket(int listen_port) {
             error("unable to listen on port %d\n", listen_port);
         }
 
-        debug("socket created, listening for broadcasts on port %d\n", listen_port);
+        message("socket created, listening for broadcasts on port %d\n", listen_port);
     }
 
     port[index] = listen_port;
@@ -222,7 +222,7 @@ can_frame *receive_frame(int socketfd, int port, uint8_t *message, int message_l
 }
 
 void set_broadcast_address(char *address) {
-    debug("setting broadcast address to %s\n", address);
+    message("setting broadcast address to %s\n", address);
     broadcast_address = address;
 }
 
@@ -243,8 +243,8 @@ int broadcast_frame(int from_port, int to_port, can_frame *frame) {
     memcpy(&frame_to_send, frame, sizeof(can_frame));
     frame_to_send.can_id = htonl(frame->can_id);
 
-    debug("sending frame to broadcast address %s:%d\n",
-        inet_ntoa(broadcast_addr.sin_addr), to_port);
+    message("sending frame to broadcast address %s:%d\n",
+            inet_ntoa(broadcast_addr.sin_addr), to_port);
     return sendto(udp_socket(from_port), &frame_to_send, 
                   5 + frame_to_send.can_dlc, 0, // no flags
                   (struct sockaddr *) &broadcast_addr, 

--- a/besspin/cyberPhys/infotainment-server/source/infotainment_debug.h
+++ b/besspin/cyberPhys/infotainment-server/source/infotainment_debug.h
@@ -10,8 +10,24 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifndef INFOTAINMENT_DEBUG_FLAG
+#define INFOTAINMENT_DEBUG_FLAG 0
+#endif
+
 // basic debug and error output functions
+/**
+ * An error. Prints and then exits the program.
+ */
 #define error(args...) { fprintf(stderr, ##args); exit(1); }
-#define debug(args...) { fprintf(stderr, ##args); }
+
+/**
+ * A message. Prints unconditionally.
+ */
+#define message(args...) { fprintf(stderr, ##args); }
+
+/**
+ * A debug message. Only prints if DEBUG_FLAG is 1.
+ */
+#define debug(args...) { if (INFOTAINMENT_DEBUG_FLAG) { fprintf(stderr, ##args); } }
 
 #endif // __INFOTAINMENT_DEBUG_H__

--- a/besspin/cyberPhys/infotainment-server/source/infotainment_server.c
+++ b/besspin/cyberPhys/infotainment-server/source/infotainment_server.c
@@ -60,7 +60,7 @@ int main_loop(void) {
     uint8_t message[MESSAGE_BUFFER_SIZE];
     can_frame *frame;
 
-    debug("socket number is %d\n", udp_socket(RECEIVE_PORT));
+    message("socket number is %d\n", udp_socket(RECEIVE_PORT));
     
     while (the_state.T == RUNNING) {
         // zero out the buffer
@@ -111,7 +111,7 @@ int main_loop(void) {
         }
     }
 
-    debug("stop signal received, cleaning up\n");
+    message("stop signal received, cleaning up\n");
     // close the UDP socket in an orderly fashion since we're
     // no longer listening
     close(udp_socket(RECEIVE_PORT));
@@ -156,7 +156,7 @@ bool update_position(can_frame *frame) {
     } else {
         *old_position = position;
         changed = true;
-        debug("updated %c position to %f\n", dimension, *old_position);
+        message("updated %c position to %f\n", dimension, *old_position);
     }
 
     return changed;
@@ -172,28 +172,28 @@ bool handle_button_press(can_frame *frame) {
 
     switch (*payload) {
         case BUTTON_STATION_1:
-            debug("station 1 set\n");
+            message("station 1 set\n");
             changed = set_station(1);
             break;
         case BUTTON_STATION_2:
-            debug("station 2 set\n");
+            message("station 2 set\n");
             changed = set_station(2);
             break;
         case BUTTON_STATION_3:
-            debug("station 3 set\n");
+            message("station 3 set\n");
             changed = set_station(3);
             break;
         case BUTTON_VOLUME_DOWN:
-            debug("volume down pressed\n");
+            message("volume down pressed\n");
             changed = decrease_volume();
             break;
         case BUTTON_VOLUME_UP:
-            debug("volume up pressed\n");
+            message("volume up pressed\n");
             changed = increase_volume();
             break;
         default:
-            debug("invalid button press (%d) received, ignoring\n", 
-                  *payload);
+            message("invalid button press (%d) received, ignoring\n", 
+                    *payload);
     }
 
     return changed;
@@ -266,8 +266,8 @@ void broadcast_music_state() {
                         .can_dlc = BYTE_LENGTH_INFOTAINMENT_STATE };
     frame.data[0] = data;
 
-    debug("broadasting music state frame: playing %d, station %d, volume %d\n",
-          the_state.M == MUSIC_PLAYING, the_state.station, the_state.volume);
+    message("broadasting music state frame: playing %d, station %d, volume %d\n",
+            the_state.M == MUSIC_PLAYING, the_state.station, the_state.volume);
     broadcast_frame(RECEIVE_PORT, SEND_PORT, &frame);
 }
 
@@ -284,7 +284,7 @@ void broadcast_position(canid_t can_id) {
     float network_position = iu_htonf(*position);
     memcpy(&frame.data[0], &network_position, sizeof(float));
 
-    debug("broadcasting new %c position: %f\n", dimension, *position);
+    message("broadcasting new %c position: %f\n", dimension, *position);
     broadcast_frame(RECEIVE_PORT, SEND_PORT, &frame);
 }
 
@@ -309,6 +309,6 @@ void broadcast_heartbeat_ack(can_frame *frame) {
 }
 
 void stop(void) {
-    debug("stopping state machine after current iteration\n");
+    message("stopping state machine after current iteration\n");
     the_state.T = STOP;
 }

--- a/besspin/cyberPhys/infotainment-server/source/infotainment_utils.c
+++ b/besspin/cyberPhys/infotainment-server/source/infotainment_utils.c
@@ -39,20 +39,20 @@ int udp_socket(int listen_port) {
     if (getsockname(socketfd, (struct sockaddr *) &current_address, &current_len) == 0) {
         if (ntohs(current_address.sin_port) != listen_port) {
             // it's listening on the wrong port, close it
-            debug("closing socket on port %d\n", ntohs(current_address.sin_port));
+            message("closing socket on port %d\n", ntohs(current_address.sin_port));
             close(socketfd);
             socketfd = -1;
         } // else we leave the socket alone
     } else {
         // couldn't get socket status, reset it to -1
-        debug("couldn't get socket status for socket %d, errno %d\n", 
-              socketfd, errno);
+        message("couldn't get socket status for socket %d, errno %d\n", 
+                socketfd, errno);
         socketfd = -1;
     }
 
     // create the socket if it doesn't exist or has been closed     
     if (socketfd < 0 || (fcntl(socketfd, F_GETFD) == -1 && errno != EBADF)) {
-        debug("creating socket on port %d\n", listen_port);
+        message("creating socket on port %d\n", listen_port);
 
         if ((socketfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) == -1) {
             error("unable to create socket: error %d\n", errno);
@@ -83,7 +83,7 @@ int udp_socket(int listen_port) {
             error("unable to listen on port %d\n", listen_port);
         }
 
-        debug("socket created, listening for broadcasts on port %d\n", listen_port);
+        message("socket created, listening for broadcasts on port %d\n", listen_port);
     }
 
     return socketfd;   
@@ -189,7 +189,7 @@ can_frame *receive_frame(int port, uint8_t *message, int message_len,
 }
 
 void set_broadcast_address(char *address) {
-    debug("setting broadcast address to %s\n", address);
+    message("setting broadcast address to %s\n", address);
     broadcast_address = address;
 }
 
@@ -210,7 +210,7 @@ int broadcast_frame(int from_port, int to_port, can_frame *frame) {
     memcpy(&frame_to_send, frame, sizeof(can_frame));
     frame_to_send.can_id = htonl(frame->can_id);
 
-    debug("sending frame to broadcast address %s:%d\n",
+    message("sending frame to broadcast address %s:%d\n",
         inet_ntoa(broadcast_addr.sin_addr), to_port);
     return sendto(udp_socket(from_port), &frame_to_send, 
                   5 + frame_to_send.can_dlc, 0, // no flags


### PR DESCRIPTION
This adds another level of debugging output, unconditional messages, as well as a compile-time flag to determine whether debugging output will actually be generated. The idea here is that, with default compilation options (`make`), you will get infotainment servers (both good and evil) that only output logging information about infotainment CAN messages that are acted upon; otherwise, you get a lot more logging information about every CAN message that comes across the network, including detail about where they're from and how they're handled. `make DEBUG=1` builds binaries that do the original, very verbose, logging.
