### PR TITLE
Add variants to test 128

### DIFF
--- a/besspin/cwesEvaluation/numericErrors/cweScores.py
+++ b/besspin/cwesEvaluation/numericErrors/cweScores.py
@@ -36,8 +36,8 @@ def partitionLines (lines,testPart,testNum):
     startFound = False
     iStart = 0
     iEnd = len(lines)-1
-    start = f"TEST {testNum} PART P{testPart:02d}"
-    end = f"TEST {testNum} PART P{(testPart+1):02d}"
+    start = f"TEST test_{testNum} PART P{testPart:02d}"
+    end = f"TEST test_{testNum} PART P{(testPart+1):02d}"
     for iLine,line in enumerate(lines):
         if (start in line):
             startFound = True

--- a/besspin/cwesEvaluation/numericErrors/cweScores.py
+++ b/besspin/cwesEvaluation/numericErrors/cweScores.py
@@ -36,8 +36,8 @@ def partitionLines (lines,testPart,testNum):
     startFound = False
     iStart = 0
     iEnd = len(lines)-1
-    start = f"TEST test_{testNum} PART P{testPart:02d}"
-    end = f"TEST test_{testNum} PART P{(testPart+1):02d}"
+    start = f"TEST {testNum} PART P{testPart:02d}"
+    end = f"TEST {testNum} PART P{(testPart+1):02d}"
     for iLine,line in enumerate(lines):
         if (start in line):
             startFound = True

--- a/besspin/cwesEvaluation/numericErrors/setupEnv.json
+++ b/besspin/cwesEvaluation/numericErrors/setupEnv.json
@@ -19,15 +19,19 @@
                 "test_128": {
                     "cweText": "Wrap-around Error",
                     "unix": {
-                        "nParts": 2,
+                        "nParts": 4,
                         "scoreWeights": [
+                            1,
+                            1,
                             1,
                             1
                         ]
                     },
                     "FreeRTOS": {
-                        "nParts": 2,
+                        "nParts": 4,
                         "scoreWeights": [
+                            1,
+                            1,
                             1,
                             1
                         ]

--- a/besspin/cwesEvaluation/numericErrors/sources/test_128.c
+++ b/besspin/cwesEvaluation/numericErrors/sources/test_128.c
@@ -42,6 +42,7 @@ static __attribute__((noinline)) uint8_t mult_8 (uint8_t in1, uint8_t in2);
             testpart = 0;
         } 
 #endif
+        printf ("TEST 128 PART P0%d\n",testpart);
         switch(testpart) {
             case 1 :
                 test_op_dtype_xlen(testpart, MULT);

--- a/besspin/cwesEvaluation/numericErrors/sources/test_128.c
+++ b/besspin/cwesEvaluation/numericErrors/sources/test_128.c
@@ -1,181 +1,165 @@
-// This test is adapted from the example code
-// cited in the SEI's CERT C Coding Standard
-// Rule MEM07-C
-
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdlib.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-
 #include "testsParameters.h"
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdint.h>
 
 #if (defined(BESSPIN_FREERTOS) && defined(BESSPIN_FPGA))
-#include "FreeRTOS.h"
-#define FREE vPortFree
-#define MALLOC pvPortMalloc
-#else
-#define FREE free
-#define MALLOC malloc
+    #include "FreeRTOS.h"
 #endif
 
-#define NUM_OF_TEST_PARTS 2
+#define NUM_OF_TEST_PARTS 4
 
-void check_test_error(bool error, int part) {
+#if __riscv_xlen == 64
+    #define UINT_MAX UINT64_MAX
+#elif __riscv_xlen == 32
+    #define UINT_MAX UINT32_MAX
+#endif
+
+enum operation {MULT, ADD};
+
+static void test_op_dtype_xlen(int part, enum operation op);
+static void test_op_dtype_8(int part, enum operation op);
+static void check_test_error(bool error, int part);
+static __attribute__((noinline)) size_t add_xlen (size_t in1, size_t in2);
+static __attribute__((noinline)) uint8_t add_8 (uint8_t in1, uint8_t in2);
+static __attribute__((noinline)) size_t mult_xlen (size_t in1, size_t in2);
+static __attribute__((noinline)) uint8_t mult_8 (uint8_t in1, uint8_t in2);
+
+#ifdef BESSPIN_FREERTOS
+    #define NUM_OF_TEST_PARTS 8
+    void main() {
+        int testpart = BESSPIN_TEST_PART;
+#elif (defined(BESSPIN_DEBIAN) || defined(BESSPIN_FREEBSD))
+    #include "unbufferStdout.h"
+    int main(int argc, char *argv[]);
+
+    int main(int argc, char *argv[]) {
+        unbufferStdout();
+        int testpart;
+        if (argc > 1) { //be safe
+            testpart = atoi(argv[1]);
+        } else {
+            testpart = 0;
+        } 
+#endif
+        switch(testpart) {
+            case 1 :
+                test_op_dtype_xlen(testpart, MULT);
+                break;
+            case 2 :
+                test_op_dtype_xlen(testpart, ADD);
+                break;
+            case 3 :
+                test_op_dtype_8(testpart, MULT);
+                break;
+            case 4 :
+                test_op_dtype_8(testpart, ADD);
+                break;
+            default :
+                check_test_error(true, testpart);
+        }
+
+        #ifdef BESSPIN_FREERTOS
+            return;
+        #elif (defined(BESSPIN_DEBIAN) || defined(BESSPIN_FREEBSD))
+            return 0;
+        #endif
+    }
+
+static void check_test_error(bool error, int part) {
   if (error) {
     printf("SCORE:128:%d:TEST ERROR\n", part);
     exit(1);
-  }
-}
-
-/**
- * Overflow a size_t input to malloc to allocate a 0 byte buffer and overrun
- * the buffer
- */
-void test_size_t(void) {
-  size_t s;
-  size_t l;
-  int *ptr_1;
-  int *ptr_2;
-
-  printf ("TEST 128 PART P01\n");
-
-  printf ("Size of size_t is %d\n", sizeof(size_t));
-
-  if (sizeof(size_t) == 4)
-    {
-      l = (UINT32_MAX / sizeof(int)) + 1;
-      // note that printf() on FreeRTOS does not support the %zu
-      // format specifier
-      printf ("UINT32_MAX is %u\n", (size_t) UINT32_MAX);
-      printf ("l is %u\n", l);
-    }
-  else // assume 8
-    {
-      l = (UINT64_MAX / sizeof(int)) + 1;
-      printf ("UINT64_MAX is %zu\n", (size_t) UINT64_MAX);
-      printf ("l is %zu\n", l);
-    }
-
-  // First, let's try a case that should work fine
-  s = 1024 * sizeof(int);
-  printf ("Going to malloc %u bytes\n", s);
-  ptr_1 = (int *) MALLOC(s);
-  check_test_error(!ptr_1, 1);
-  for (size_t j = 0; j < 1024; j++) {
-    ptr_1 [j] = 0;
-  }
-  FREE(ptr_1);
-  printf ("Alloc and init of 1024 ints successful\n");
-
-  // Second, a case that is contrived to fail
-  s = l * sizeof(int); // Overflow back to zero since size_t is unsigned
-
-  // A SSITH CPU might spot the problem above and halt the program here.
-  // To PASS this test, a SSITH CPU should prevent the numeric overflow here
-  // and print "<ABORT>" on stdout via whatever exception handling mechanism
-  // is appropriate for that CPU and OS.
-
-  if (sizeof(size_t) == 4)
-    printf ("Going to malloc %u bytes\n", s);
-  else
-    printf ("Going to malloc %zu bytes\n", s);
-
-  // Possibly attempt to malloc(0). Some implementations of malloc()
-  // will check and fail here.
-  ptr_2 = (int *) MALLOC(s);
-
-  // A SSITH CPU might spot the problem above and halt the program here.
-  // To PASS this test, a SSITH CPU should prevent the malloc(0)
-  // and print "<ABORT>" on stdout via whatever exception handling mechanism
-  // is appropriate for that CPU and OS.
-
-  check_test_error(!ptr_2, 1);
-  for (size_t j = 0; j < 16; j++) {
-    // Limit to first 16 elements to ensure termination
-    ptr_2 [j] = 0;
-  }
-  FREE(ptr_2);
-
-  // If still executing at this point, then we consider the test to be a FAIL
-  printf ("SCORE:128:1:TEST FAILED\n");
-}
-
-/**
- * Overflow a uint8_t input to malloc to allocate a 0 byte buffer and overrun
- * the buffer
- */
-void test_uint8_t(void) {
-  // Number of elements in first buffer
-  const int ELEMENTS_1 = 64;
-  const int ELEMENTS_2 = 128;
-
-  printf ("TEST 128 PART P02\n");
-
-  // Perform an allocation that should work (128 bytes)
-  uint8_t size_1 = ELEMENTS_1 * sizeof(uint16_t);
-  printf("Going to malloc %u bytes\n", (unsigned int) size_1);
-  uint16_t *ptr_1 = (uint16_t*) MALLOC(size_1);
-  check_test_error(!ptr_1, 2);
-  for (int i = 0; i < ELEMENTS_1; ++i) {
-    ptr_1[i] = 0;
-  }
-  FREE(ptr_1);
-  printf("Alloc and init of %d uint16_ts successful\n", ELEMENTS_1);
-
-  // Overflow size_2 and malloc(0)
-  uint8_t size_2 = ELEMENTS_2 * sizeof(uint16_t);  // Overflows to 0
-  printf("Going to malloc %u bytes\n", (unsigned int) size_2);
-  uint16_t *ptr_2 = (uint16_t*) MALLOC(size_2);
-  check_test_error(!ptr_2, 2);
-  for (int i = 0; i < 16; ++i) {
-    // Limit to first 16 elements to avoid segfault
-    ptr_2[i] = 0;
-  }
-  FREE(ptr_2);
-  // If still executing at this point, then we consider the test to be a FAIL
-  printf ("SCORE:128:2:TEST FAILED\n");
-}
-#ifdef BESSPIN_FREERTOS
-//---------------- FreeRTOS test ------------------------------------------------------
-
-int main()
-{
-#if BESSPIN_TEST_PART == 1
-  test_size_t();
-#elif BESSPIN_TEST_PART == 2
-  test_uint8_t();
-#else
-  printf ("SCORE:456:%d:TEST ERROR\n",BESSPIN_TEST_PART);
-#endif
-  return 0;
-}
-
-//---------------- Debian && FreeBSD test ------------------------------------------------------
-#elif (defined(BESSPIN_DEBIAN) || defined(BESSPIN_FREEBSD))
-#include "unbufferStdout.h"
-
-int main(int argc, char **argv) {
-  unbufferStdout();
-  int testpart;
-  if (argc > 1) {
-    testpart = atoi(argv[1]);
   } else {
-    testpart = 0;
+    printf("<GOOD>\n");
   }
-
-  switch (testpart) {
-    case 1:
-      test_size_t();
-      break;
-    case 2:
-      test_uint8_t();
-      break;
-    default:
-      check_test_error(true, testpart);
-  }
-
-  return 0;
 }
-#endif
+
+static void test_op_dtype_xlen(int part, enum operation op) {
+    size_t dut;
+
+    // First, a benign case
+    switch (op) {
+        case MULT:
+            dut = mult_xlen(200, 5);
+            break;
+        case ADD:
+            dut = add_xlen(150, 850);
+            break;
+        default:
+            check_test_error(true, part);
+    }
+    printf("DUT = <%lu>\n",dut);
+    check_test_error (dut!=1000,part);
+
+    // Second, a malicious case
+    if (op==MULT)
+        dut = mult_xlen((UINT_MAX / 4) + 1, 4); // wrap-around
+    else
+        dut = add_xlen(UINT_MAX - 32 + 1, 32); // wrap-around
+
+    printf("DUT = <%lu>\n",dut);
+    check_test_error (dut!=0,part); 
+
+    printf ("SCORE:128:%d:TEST FAILED\n",part);
+    return;
+}
+
+static void test_op_dtype_8(const int part, const enum operation op) {
+    uint8_t dut;
+
+    // First, a benign case
+    switch (op) {
+        case MULT:
+            dut = mult_8(20, 5);
+            break;
+        case ADD:
+            dut = add_8(15, 85);
+            break;
+        default:
+            check_test_error(true, part);
+    }
+    printf("DUT = <%d>\n",dut);
+    check_test_error (dut!=100,part);
+
+    // Second, a malicious case
+    if (op == MULT)
+        dut = mult_8(64, 4); // wrap-around
+    else
+        dut = add_8(224, 32); // wrap-around
+
+    printf("DUT = <%d>\n",dut);
+    check_test_error (dut!=0,part); 
+
+    printf ("SCORE:128:%d:TEST FAILED\n",part);
+    return;
+}
+
+static __attribute__((noinline)) size_t add_xlen (size_t in1, size_t in2) {
+    size_t ret = 0;
+    ret += in1;
+    ret += in2;
+    return ret;
+}
+
+static __attribute__((noinline)) uint8_t add_8 (uint8_t in1, uint8_t in2) {
+    uint8_t ret = 0;
+    ret += in1;
+    ret += in2;
+    return ret;
+}
+
+static __attribute__((noinline)) size_t mult_xlen (size_t in1, size_t in2) {
+    size_t ret = 1;
+    ret *= in1;
+    ret *= in2;
+    return ret;
+}
+
+static __attribute__((noinline)) uint8_t mult_8 (uint8_t in1, uint8_t in2) {
+    uint8_t ret = 1;
+    ret *= in1;
+    ret *= in2;
+    return ret;
+}
+

--- a/besspin/cwesEvaluation/scoreTests.py
+++ b/besspin/cwesEvaluation/scoreTests.py
@@ -146,7 +146,7 @@ class SCORES (enum.Enum):
     def weightedAvgScore (cls, scoreList, partsWeights):
         minScore = cls.minScore(scoreList)
         if (minScore < cls.HIGH): #One of the parts has an error --> error
-            return minScore
+            return (minScore, minScore.value)
         sumScores = 0
         for xScore, xWeight in zip(scoreList, partsWeights):
             sumScores += xWeight * xScore.value

--- a/ci/configs.py
+++ b/ci/configs.py
@@ -34,8 +34,11 @@ commonDefaultsFETT = {
 commonDefaultsCWEs = {
     ('mode',('evaluateSecurityTests',)),
     ('vulClasses', ('[bufferErrors, PPAC, resourceManagement, informationLeakage, numericErrors, hardwareSoC, injection]',)),
+    ('checkAgainstValidScores',('Yes',)),
     ('useCustomScoring',('No',)),
     ('useCustomCompiling',('No',)),
+    ('computeNaiveCWEsTally',('Yes',)),
+    ('computeBesspinScale',('Yes',)),
     ('FreeRTOStimeout',(10,)),
     ('runAllTests',('Yes',)),
     ('runUnixMultitaskingTests',('Yes',)),

--- a/ci/configs.py
+++ b/ci/configs.py
@@ -6,8 +6,8 @@
     Each tuple represents one setting and its possible values.
     Each "values" should be a tuple. Please note that a 1-element tuple should be: ('element',)
 """
-backupBesspinAMI = { 'ImageId' : 'ami-07fc3f8f4525f1c94', 
-                'CreationDate' : '2020-09-08T16:28:43.000Z',
+backupBesspinAMI = { 'ImageId' : 'ami-067bd21562d1f150e', 
+                'CreationDate' : '2021-05-19T20:09:51.000Z',
                 'OwnerId' : '363527286999'} 
 # Please update occasionally. Used by ./utils.getBesspinAMI() instead of erring.
 


### PR DESCRIPTION
Closes #1231 

- Re-write test 128 to include addition variant -- still static constants. Also, removed the malloc(0) parts; what was the point anyway?
- fix a bug in scoreTests
- Update ci/configs.py