### PR TITLE
Add a mode that leaks pointers instead of strings

### DIFF
--- a/besspin/cwesEvaluation/informationLeakage/sources/include/control.h
+++ b/besspin/cwesEvaluation/informationLeakage/sources/include/control.h
@@ -1,11 +1,15 @@
 #ifndef __CONTROL_H__
 #define __CONTROL_H__
 
+#ifndef __IEX_GEN__CAPABILITIES__
 #ifdef __IEX_GEN__ARRAYS__
 extern char secret[OBJ_SIZE];
 #else
 extern char *secret;
 #endif // !ARRAYS/STATIC
+#else // __IEX_GEN__CAPABILITIES__
+extern uintptr_t *secret;
+#endif // __IEX_GEN__CAPABILITIES__
 
 // For checking test dependencies
 extern char *STORE_IMPL;
@@ -33,13 +37,13 @@ send_and_run(struct umessage *msg);
 
 // return 1 <=> `str` contains the secret value
 int
-matches_secret(const char *str);
+matches_secret(const void *str);
 
 // Removes the secret value from `in`, copying result
 // into `out` buffer. Both buffers should have size
 // `in_size`
 void
-scrub(const char *in, size_t in_size, char *out);
+scrub(const void *in, size_t in_size, void *out);
 
 //////////////////////////////////
 // Wrappers around OS interface //

--- a/besspin/cwesEvaluation/informationLeakage/sources/include/parameters/parameters.h
+++ b/besspin/cwesEvaluation/informationLeakage/sources/include/parameters/parameters.h
@@ -5,7 +5,16 @@
 #define SECRET_TEXT "#!SECRET#!"
 #define SECRET_PATTERN PAD SECRET_TEXT PAD
 #define NOT_SECRET     PAD "BG" PAD
-#define PATTERN_SIZE (2*sizeof(PAD) + sizeof(SECRET_TEXT) - 2)
 
+#ifdef BIN_SOURCE_SRI_Cambridge
+#define __IEX_GEN__CAPABILITIES__
+#else
 #define __IEX_GEN__STATIC_SECRET__
 #define __IEX_GEN__ARRAYS__
+#endif
+
+#ifndef __IEX_GEN__CAPABILITIES__
+#define PATTERN_SIZE (2*sizeof(PAD) + sizeof(SECRET_TEXT) - 2)
+#else
+#define PATTERN_SIZE (3 * sizeof(uintptr_t))
+#endif

--- a/besspin/cwesEvaluation/informationLeakage/sources/include/types.h
+++ b/besspin/cwesEvaluation/informationLeakage/sources/include/types.h
@@ -4,6 +4,18 @@
 #include <stdint.h>
 #include <stdio.h>
 #include "parameters.h"
+#ifdef __IEX_GEN__CAPABILITIES__
+#include <machine/cherireg.h>
+#include <cheri/cheric.h>
+#endif
+
+#ifndef __IEX_GEN__CAPABILITIES__
+#define STORE_ALIGN
+#define STRIP_STORE_LOCAL(x) (x)
+#else
+#define STORE_ALIGN __attribute__((aligned(sizeof(uintptr_t))))
+#define STRIP_STORE_LOCAL(x) cheri_andperm((x), ~CHERI_PERM_STORE_LOCAL_CAP)
+#endif
 
 #ifndef STORE_SIZE
 #error "STORE_SIZE undefined"

--- a/besspin/cwesEvaluation/informationLeakage/sources/stores/cached.c
+++ b/besspin/cwesEvaluation/informationLeakage/sources/stores/cached.c
@@ -11,13 +11,13 @@ char *STORE_IMPL   = "CACHED";
 struct store_obj {
     int domain;
     saddr_t addr;
-    char data[OBJ_SIZE];
+    char data[OBJ_SIZE] STORE_ALIGN;
 };
 
 #ifdef __IEX_GEN__ARRAYS__
-struct store_obj public_store[STORE_SIZE]   = {0};
-struct store_obj system_store[STORE_SIZE]   = {0};
-struct store_obj store[NDOMAINS*STORE_SIZE] = {0};
+struct store_obj public_store[STORE_SIZE] STORE_ALIGN   = {0};
+struct store_obj system_store[STORE_SIZE] STORE_ALIGN   = {0};
+struct store_obj store[NDOMAINS*STORE_SIZE] STORE_ALIGN = {0};
 #else
 struct store_obj *public_store;
 struct store_obj *system_store;
@@ -121,7 +121,7 @@ store_get(int domain, saddr_t addr)
     int off = OBJ_OFF(addr);
     struct store_get_res *ret = test_malloc(sizeof(*ret));
     ret->size   = OBJ_SIZE;
-    ret->result = test_malloc(OBJ_SIZE);
+    ret->result = STRIP_STORE_LOCAL(test_malloc(OBJ_SIZE));
 
     struct store_obj *target = NULL;
     if (cache_ptr && cached.domain == domain && cached.addr == obj) {

--- a/besspin/cwesEvaluation/informationLeakage/sources/stores/flatstore.c
+++ b/besspin/cwesEvaluation/informationLeakage/sources/stores/flatstore.c
@@ -9,9 +9,9 @@ char *STORE_IMPL   = "FLATSTORE";
 const size_t store_size = OBJ_SIZE*STORE_SIZE*NDOMAINS;
 
 #ifdef __IEX_GEN__ARRAYS__
-static char public_store[OBJ_SIZE*STORE_SIZE] =  {0};
-static char system_store[OBJ_SIZE*STORE_SIZE] =  {0};
-static char store[OBJ_SIZE*STORE_SIZE*NDOMAINS] = {0};
+static char public_store[OBJ_SIZE*STORE_SIZE] STORE_ALIGN   = {0};
+static char system_store[OBJ_SIZE*STORE_SIZE] STORE_ALIGN   = {0};
+static char store[OBJ_SIZE*STORE_SIZE*NDOMAINS] STORE_ALIGN = {0};
 #else
 static char *public_store;
 static char *system_store;
@@ -84,7 +84,7 @@ store_get(int domain, saddr_t addr)
     struct store_get_res *ret = test_malloc(sizeof(*ret));
     puts("get malloc\r\n");
     ret->size   = OBJ_SIZE;
-    ret->result = test_malloc(OBJ_SIZE);
+    ret->result = STRIP_STORE_LOCAL(test_malloc(OBJ_SIZE));
     puts("res malloc\r\n");
     DEBUG_PRINTF("DOM: %d\n", domain);
     DEBUG_PRINTF("addr: %d\n", ADDR_SADDR(addr));

--- a/besspin/cwesEvaluation/informationLeakage/sources/stores/fragmented.c
+++ b/besspin/cwesEvaluation/informationLeakage/sources/stores/fragmented.c
@@ -11,14 +11,14 @@ char *__STORE_CWES = "";
 struct store_obj {
     int domain;
     saddr_t addr;
-    char data[OBJ_SIZE + 1];
+    char data[OBJ_SIZE + 1] STORE_ALIGN;
 };
 
 #ifdef __IEX_GEN__ARRAYS__
-struct store_obj public_store[STORE_SIZE]   = {0};
-struct store_obj system_store_a[STORE_SIZE] = {0};
-struct store_obj store[NDOMAINS*STORE_SIZE] = {0};
-struct store_obj system_store_b[STORE_SIZE] = {0};
+struct store_obj public_store[STORE_SIZE] STORE_ALIGN   = {0};
+struct store_obj system_store_a[STORE_SIZE] STORE_ALIGN = {0};
+struct store_obj store[NDOMAINS*STORE_SIZE] STORE_ALIGN = {0};
+struct store_obj system_store_b[STORE_SIZE] STORE_ALIGN = {0};
 #else
 struct store_obj *public_store;
 struct store_obj *system_store_a;
@@ -102,7 +102,7 @@ store_get(int domain, saddr_t addr)
     int off = OBJ_OFF(addr);
     struct store_get_res *ret = test_malloc(sizeof(*ret));
     ret->size   = OBJ_SIZE;
-    ret->result = test_malloc(OBJ_SIZE);
+    ret->result = STRIP_STORE_LOCAL(test_malloc(OBJ_SIZE));
 
     struct store_obj *target = NULL;
     target = find(domain, addr);

--- a/besspin/cwesEvaluation/informationLeakage/sources/stores/separate.c
+++ b/besspin/cwesEvaluation/informationLeakage/sources/stores/separate.c
@@ -13,20 +13,20 @@ char *STORE_IMPL   = "SEPARATE";
 const size_t store_size = OBJ_SIZE*STORE_SIZE*NDOMAINS;
 // TODO: what to do here?
 #ifdef __IEX_GEN__ARRAYS__
-static char public_store[OBJ_SIZE*STORE_SIZE] = {0};
-static char store_secret[OBJ_SIZE*STORE_SIZE] = {0};
-static char store_0[OBJ_SIZE*STORE_SIZE] = {0};
+static char public_store[OBJ_SIZE*STORE_SIZE] STORE_ALIGN = {0};
+static char store_secret[OBJ_SIZE*STORE_SIZE] STORE_ALIGN = {0};
+static char store_0[OBJ_SIZE*STORE_SIZE] STORE_ALIGN = {0};
 #if NDOMAINS > 1
-static char store_1[OBJ_SIZE*STORE_SIZE] = {0};
+static char store_1[OBJ_SIZE*STORE_SIZE] STORE_ALIGN = {0};
 #endif
 #if NDOMAINS > 2
-static char store_2[OBJ_SIZE*STORE_SIZE] = {0};
+static char store_2[OBJ_SIZE*STORE_SIZE] STORE_ALIGN = {0};
 #endif
 #if NDOMAINS > 3
-static char store_3[OBJ_SIZE*STORE_SIZE] = {0};
+static char store_3[OBJ_SIZE*STORE_SIZE] STORE_ALIGN = {0};
 #endif
 #if NDOMAINS > 4
-static char store_4[OBJ_SIZE*STORE_SIZE] = {0};
+static char store_4[OBJ_SIZE*STORE_SIZE] STORE_ALIGN = {0};
 #endif
 #else
 static char *public_store;
@@ -120,7 +120,7 @@ store_get(int domain, saddr_t addr)
 #ifdef DEBUG
     printf("GET(%d, (%d, %d)) >> ", domain, OBJ_ADDR(addr), (char)OBJ_OFF(addr));
 #endif
-    struct store_get_res *ret = test_malloc(sizeof(*ret));
+    struct store_get_res *ret = STRIP_STORE_LOCAL(test_malloc(sizeof(*ret)));
     ret->size   = OBJ_SIZE;
     ret->result = test_malloc(OBJ_SIZE);
 


### PR DESCRIPTION
The new code stores a secret pointer surrounded by two pads pointers
(NULL-derived capabilities on CHERI).  The secret pointer is stored
without the GLOBAL bit set (making it LOCAL) and when allocating results
buffers, the STORE_LOCAL permission is stripped from the buffer.  This
causes a fault when attempting to retrieve the secret value.

Enable this mode on SRI/Cambridge systems.