### PR TITLE
Fix reset components

### DIFF
--- a/besspin/cyberPhys/build.py
+++ b/besspin/cyberPhys/build.py
@@ -83,10 +83,6 @@ def copyInfotainmentServerFiles(tarName, targetId=None):
         logAndExit(f"Installing infotainment-server is not supported on <{osImage}>",
                    exitCode=EXIT.Dev_Bug)
 
-    # Add the script to kill any service listening on port 5002
-    cpFilesToBuildDir(runtimeFilesDir, pattern="kill_listeners.sh", targetId=targetId)
-    tarFiles += ["kill_listeners.sh"]
-
     buildDirPathTuplePartial = functools.partial(buildDirPathTuple, targetId=targetId)
     filesList=map(buildDirPathTuplePartial, tarFiles)
     return filesList

--- a/besspin/cyberPhys/build.py
+++ b/besspin/cyberPhys/build.py
@@ -82,6 +82,10 @@ def copyInfotainmentServerFiles(tarName, targetId=None):
     else:
         logAndExit(f"Installing infotainment-server is not supported on <{osImage}>",
                    exitCode=EXIT.Dev_Bug)
+    
+    # Add the script to kill any service listening on port 5002
+    cpFilesToBuildDir(runtimeFilesDir, pattern="kill_listeners.sh", targetId=targetId)
+    tarFiles += ["kill_listeners.sh"]
 
     buildDirPathTuplePartial = functools.partial(buildDirPathTuple, targetId=targetId)
     filesList=map(buildDirPathTuplePartial, tarFiles)

--- a/besspin/cyberPhys/configs/config-cyberphys-debian.ini
+++ b/besspin/cyberPhys/configs/config-cyberphys-debian.ini
@@ -1,0 +1,288 @@
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Full documentation explaining all settings can be found (or pointed to) in ./docs/base/configuration.md.
+# Keep the comments on seperate lines from values. Order of parameters does not matter, but section headers are required.
+# Parameters names are case sensitive.
+# For bool types, you can use 0/1, False/True, Yes/No [Case insensitive].
+# --- Developer Help:
+# To add a new configuration parameter, please edit "base/utils/configData.json" with the 
+# description, type, and limits of the argument.
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+# besspin functionality options
+[functionality]
+mode = cyberPhys
+# [fettTest | fettProduction | evaluateSecurityTests | cyberPhys ]
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+#cyberPhys options and config file. This overwrites the `target` section
+[cyberPhys]
+nTargets = 3
+# Number of different targets. Note that the number of sections `[target${i}]` has to match inside the cyberPhys config
+interactiveShell = Yes
+# Opens the cyberPhys interactive shell. If disabled, the tool will launch the targets then shut them down. 
+resetOnWatchdog = Yes
+# If a target is detected to be unreachable/down, should we reset(Yes) or exit(No)?
+programBitfileOnReset = No
+# For vcu118 targets, if resetOnWatchdog is enabled, in case of a reset, should we re-program(Yes) the VCU118 bitfile?
+pipeTheUart = No
+# In the interactive mode, should we pipe the targets' main tty (UART on vcu118) to a TCP port or not.
+# Note that you can pipe selective targets in the interactiveShell using the command `pipe`.
+useCustomCyberPhysConfig = Yes
+# Whether to use the default cyberPhys config: $repoDir/cyberPhys.ini, or a custom one.
+pathToCustomCyberPhysConfig = besspin/cyberPhys/configs/cyberPhys-debian.ini
+# Path to the custom cyberPhys configuration.
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+# besspin environment -- NOT LOADED in "cyberPhys" mode
+[target]
+binarySource = GFE
+# [ GFE | LMCO | Michigan | MIT | SRI-Cambridge ]
+sourceVariant = default
+# [ default | purecap | temporal | combo-100 | combo-015-017-100-101-103 ] 
+# purecap and temporal are only compatible with SRI-Cambridge.
+# combo-100 and combo-015-017-100-101-103 are only compatible with LMCO on vcu118
+target = qemu
+# [ qemu | vcu118 | awsf1 ]
+vcu118Mode = nonPersistent
+# [ nonPersistent | flashProgramAndBoot | flashBoot ]. Only applicable if target is set to "vcu118".
+# You need to have physical (non-remote) access to the vcu118 board if you choose the flash options.
+processor = chisel_p1
+# [bluespec_p1, chisel_p1, bluespec_p2, chisel_p2, bluespec_p3, chisel_p3]
+osImage = FreeRTOS
+# [ debian | FreeRTOS | FreeBSD | busybox(limited) ]
+elfLoader = netboot
+# [ JTAG | netboot ]
+useCustomOsImage = No
+# Source of the OS image: If 'No', Nix/BESSPIN-LFS will be used.
+pathToCustomOsImage = /path/to/image
+# Path to the osImage in case 'useCustomOsImage' is set to Yes.
+useCustomProcessor = No
+# Source of the processor files: If 'No', Nix/BESSPIN-LFS will be used.
+pathToCustomProcessorSource = /path/to/source/directory
+# Path to a directory with all the files needed (following the structure of BESSPIN-LFS) to use the custom processor in case 'useCustomProcessor' is set to Yes.
+useCustomQemu = No
+# Source of Qemu binary:  If 'No', Nix qemu-system-riscv64 will be used.
+pathToCustomQemu = /path/to/qemu
+# Path to an appropriate qemu binary to use when useCustomQemu is yes.
+useCustomHwTarget = No
+# In a many-board system, use the HW Target specified by "customHWTarget".
+# This option has to be consistent among all targets (in case of cyberPhys mode)
+customHwTarget = localhost:3121/xilinx_tcf/Digilent/210308XXXXXX
+# The HW Target to use if useCustomHwTarget is enabled.
+useCustomTargetIp = No
+# Use a custom IP address for the target.
+# This option has to be consistent among all targets (in case of cyberPhys mode).
+customTargetIp = XXX.XXX.XXX.XXX
+# The Target IP to use if useCustomTargetIp is enabled.
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+# besspin common options
+[common]
+openConsole = No
+# returns a console for FreeBSD/debian, and shows the UART output of FreeRTOS while running.
+gdbDebug = No
+# Detaches from Openocd to allow the user to connect a GDB process to the target.
+# "openConsole" has to be enabled. Instructions are printed out with the console.
+useCustomCredentials = No
+# If 'Yes', create a user with the credentials provided in 'userName' and
+# 'userPasswordHash'. If 'No', then the user account will have username
+# 'researcher' and password 'besspin_2020'.
+userName = researcher
+# Name of user to create.  Must be 1-14 characters long and may consist only of
+# ASCII alphanumeric characters.
+userPasswordHash = $6$xcnc07LxM26Xq$VBAn8.ZfCzEf5MEpftSsCndDaxfPs5gXWjdrvrHcSA6O6eRoV5etd9V8E.BE0/q4P8pGOz96Nav3PPuXOktmv.
+# Output of crypt(3) in SHA-512 mode with user's password as input
+# You can use: `mkpasswd -m sha-512 PASSWORD` on unix
+rootUserAccess = No
+# If 'Yes', gives user root access via passwordless su on Debian and FreeBSD.
+remoteTargetIp = 172.31.34.147
+# IP address on AWS to bind the FPGA to via a 1:1 NAT
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+[fett]
+buildApps = no
+# Building only available in fettTest mode.
+freertosFatFs = default
+# Only applicable in 'fettTest' mode and if 'buildApps' is enabled
+# [ default (ramdisk for vcu118 and dosblk for awsf1) | ramdisk | dosblk (only on awsf1) | sdcard (only on vcu118) ]
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+# build settings
+[build]
+cross-compiler = GCC
+# [ GCC | Clang ]
+linker = GCC
+# [ GCC | LLD ]
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+[evaluateSecurityTests]
+vulClasses = [bufferErrors, PPAC, resourceManagement, informationLeakage, numericErrors, hardwareSoC, injection]
+# List the vulClasses whose tests are to be executed.
+# Choose from: [bufferErrors, PPAC, resourceManagement, informationLeakage, numericErrors, hardwareSoC, injection]
+useCustomCWEsConfigsPath = No
+# If 'No', then the files in `${repo}/configSecurityTests` will be used by default.
+pathToCustomCWEsConfigs = /path/to/directory-containting-configs
+# The path to the directory containing the CWEs config files
+useCustomScoring = No
+# Load the settings in the [customizedScoring] section below.
+useCustomCompiling = No
+# Load the settings in the [customizedCompiling] section below.
+computeNaiveCWEsTally = Yes
+# Whether to compute the naive CWEs tally count and scores
+computeBesspinScale = Yes
+# Whether to compute the BESSPIN Scale if possible
+FreeRTOStimeout = 10
+# The FreeRTOS test execution requires a timeout. 10 seconds is a reasonable value.
+runUnixMultitaskingTests = Yes
+# If enabled, then the compatible and selected tests will run in the multitasking mode. 
+instancesPerTestPart = 1
+# The number of instances of each test part to spawn as separate processes when running multitasking tests.
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+[customizedScoring]
+stdoutKeywords = []
+# List of keywords (comma separated, white spaces) in stdout that means that the processor has detected a violation.
+gdbKeywords = []
+# List of keywords (comma separated, white spaces) in GDB output that means that the processor has detected a violation.
+funcCheckpoints = []
+# List of functions/methods/interrupts (comma separated, white spaces) reaching which means that the processor has detected a violation.
+memAddress = -1
+# The memory address to watch for detected violations. use -1 to disable.
+memResetValue = 0
+# The value (HEX) to which the tool should reset the memAddress after a violation detection.
+memViolationValues = []
+# List of values (HEX, comma separated) that indicate that a violation was detected. For example: [0x539, FFF, 1]
+# You may use [*] to indicate the use of every value except memResetValue. 
+useCustomFunction = No
+# Use a custom python script whose main will score instead of the settings above.
+pathToCustomFunction = /path/to/python/function
+# The path to the python script. It will be passed: 1. A list of the lines from the log file. 2. The Enum object SCORES. 
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+[customizedCompiling]
+useCustomMakefile = No
+# Use a custom Makefile. This makefile will be copied to the tests directory as 'Makefile', and be executed by 'make'.
+pathToCustomMakefile = /path/to/Makefile
+# The path to the custom makefile. 
+useCustomClang = No
+# Use a custom Clang binary.
+pathToCustomClang = /path/to/clang
+# The path to the custom Clang binary (passed to make as CLANG).
+useCustomSysroot = No
+# Use a custom sysroot.
+pathToCustomSysroot = /path/to/sysroot
+# The path to the custom sysroot directory (passed to make SYSROOT).
+gccDebian = default
+# [ default | linux9.2 | bareMetal8.3 | bareMetal9.2 ]
+# Applicable only to debian/GCC, default is linux9.2.
+# linux9.2: riscv64-unknown-linux-gnu-gcc v9.2 (built with nix)
+# bareMetal8.3: riscv64-unknown-elf-gcc v8.3 (provided in the docker container <galoisinc/besspin:gfe-gcc83>) 
+# bareMetal9.2: riscv64-unknown-elf-gcc v9.2 (built with nix)
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+# Vul Class: Buffer Errors
+[bufferErrors]
+useSelfAssessment = No
+# Enable to use the CWEsConfigs for the scores instead of running the tests
+useCustomErrorModel = No
+# Enable this option to use the error model in 'pathToCustomErrorModel', rather
+# than the default error model.  This allows for configuration of the types of
+# errors the generated tests will exercise.  See 'docs/constrainBufferErrors.md'
+# for a detailed description of how to use custom error models.
+pathToCustomErrorModel = /path/to/error/model.cfr
+# Path to the error model to use when 'useCustomErrorModel' is enabled.
+numericTypes = [ints, floats]
+# List the numeric types the generated tests should use.
+# Choose from [ints, floats]
+nTests    = 100
+# The number of random tests generated.  Must be at least 40 for FreeRTOS and
+# at least 100 for debian and FreeBSD.
+nSkip     = 0
+# Before generating `nTests` tests, generate and throw away `nSkip` tests
+useSeed   = No
+# Whether to use a specific seed (instead of a random one)
+seed      = 0
+# The seed for the random generation (if useSeed is enabled)
+heapSize  = 8M
+stackSize = 8K
+# Maximum heap and stack sizes. Understands suffixes K=1024, M=1024^2
+useExtraTests = No
+# If 'Yes', then look for C files in 'extraSources' to run in addition
+# to the generated tests.
+extraSources  = /path/to/extra/sources
+# Path to directory containing C files to run as additional test cases. Each
+# test should be a self-contained C file.
+csvFile = Yes
+# tabulates the test results in a CSV file [boolean]
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+# Vul Class: Permission, Privileges and Access Control
+[PPAC]
+useSelfAssessment = No
+# Enable to use the CWEsConfigs for the scores instead of running the tests
+runAllTests = Yes
+# If disabled, then the file ${CWEsConfigs}/PPAC.ini will be used to custom configure the tests
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+# Vul Class: Resource Management
+[resourceManagement]
+useSelfAssessment = No
+# Enable to use the CWEsConfigs for the scores instead of running the tests
+runAllTests = Yes
+# If disabled, then the file ${CWEsConfigs}/resourceManagement.ini will be used to custom configure the tests
+useSeed = No
+# Whether to use a specific seed (instead of a randomly generated one at runtime)
+seed = 0
+# The seed for the random generation (if `useSeed` is enabled)
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+# Vul Class: Information Leakage
+[informationLeakage]
+useSelfAssessment = No
+# Enable to use the CWEsConfigs for the scores instead of running the tests
+runAllTests = Yes
+# If disabled, then the file ${CWEsConfigs}/informationLeakage.ini will be used to custom configure the tests
+useSeed = No
+# Whether to use a specific seed (instead of a randomly generated one at runtime)
+seed = 0
+# The seed for the random generation (if `useSeed` is enabled)
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+# Vul Class: Numeric Errors
+[numericErrors]
+useSelfAssessment = No
+# Enable to use the CWEsConfigs for the scores instead of running the tests
+runAllTests = Yes
+# If disabled, then the file ${CWEsConfigs}/numericErrors.ini will be used to custom configure the tests
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+# Vul Class: Hardware Implementation / SoC
+[hardwareSoC]
+# useSelfAssessment = Yes # Internally enabled -- Self-assessment only.
+# Enable to use the CWEsConfigs for the scores instead of running the tests
+runAllTests = Yes
+# If disabled, then the file ${CWEsConfigs}/hardwareSoC.ini will be used to custom configure the tests
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+# Vul Class: Injection
+[injection]
+useSelfAssessment = No
+# Enable to use the CWEsConfigs for the scores instead of running the tests
+runAllTests = Yes
+# If disabled, then the file ${CWEsConfigs}/injection.ini will be used to custom configure the tests
+#--------------------------------------------------------------------------------

--- a/besspin/cyberPhys/configs/config-cyberphys-freertos.ini
+++ b/besspin/cyberPhys/configs/config-cyberphys-freertos.ini
@@ -1,0 +1,288 @@
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Full documentation explaining all settings can be found (or pointed to) in ./docs/base/configuration.md.
+# Keep the comments on seperate lines from values. Order of parameters does not matter, but section headers are required.
+# Parameters names are case sensitive.
+# For bool types, you can use 0/1, False/True, Yes/No [Case insensitive].
+# --- Developer Help:
+# To add a new configuration parameter, please edit "base/utils/configData.json" with the 
+# description, type, and limits of the argument.
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+# besspin functionality options
+[functionality]
+mode = cyberPhys
+# [fettTest | fettProduction | evaluateSecurityTests | cyberPhys ]
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+#cyberPhys options and config file. This overwrites the `target` section
+[cyberPhys]
+nTargets = 3
+# Number of different targets. Note that the number of sections `[target${i}]` has to match inside the cyberPhys config
+interactiveShell = Yes
+# Opens the cyberPhys interactive shell. If disabled, the tool will launch the targets then shut them down. 
+resetOnWatchdog = Yes
+# If a target is detected to be unreachable/down, should we reset(Yes) or exit(No)?
+programBitfileOnReset = No
+# For vcu118 targets, if resetOnWatchdog is enabled, in case of a reset, should we re-program(Yes) the VCU118 bitfile?
+pipeTheUart = No
+# In the interactive mode, should we pipe the targets' main tty (UART on vcu118) to a TCP port or not.
+# Note that you can pipe selective targets in the interactiveShell using the command `pipe`.
+useCustomCyberPhysConfig = Yes
+# Whether to use the default cyberPhys config: $repoDir/cyberPhys.ini, or a custom one.
+pathToCustomCyberPhysConfig = besspin/cyberPhys/configs/cyberPhys-freertos.ini
+# Path to the custom cyberPhys configuration.
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+# besspin environment -- NOT LOADED in "cyberPhys" mode
+[target]
+binarySource = GFE
+# [ GFE | LMCO | Michigan | MIT | SRI-Cambridge ]
+sourceVariant = default
+# [ default | purecap | temporal | combo-100 | combo-015-017-100-101-103 ] 
+# purecap and temporal are only compatible with SRI-Cambridge.
+# combo-100 and combo-015-017-100-101-103 are only compatible with LMCO on vcu118
+target = qemu
+# [ qemu | vcu118 | awsf1 ]
+vcu118Mode = nonPersistent
+# [ nonPersistent | flashProgramAndBoot | flashBoot ]. Only applicable if target is set to "vcu118".
+# You need to have physical (non-remote) access to the vcu118 board if you choose the flash options.
+processor = chisel_p1
+# [bluespec_p1, chisel_p1, bluespec_p2, chisel_p2, bluespec_p3, chisel_p3]
+osImage = FreeRTOS
+# [ debian | FreeRTOS | FreeBSD | busybox(limited) ]
+elfLoader = netboot
+# [ JTAG | netboot ]
+useCustomOsImage = No
+# Source of the OS image: If 'No', Nix/BESSPIN-LFS will be used.
+pathToCustomOsImage = /path/to/image
+# Path to the osImage in case 'useCustomOsImage' is set to Yes.
+useCustomProcessor = No
+# Source of the processor files: If 'No', Nix/BESSPIN-LFS will be used.
+pathToCustomProcessorSource = /path/to/source/directory
+# Path to a directory with all the files needed (following the structure of BESSPIN-LFS) to use the custom processor in case 'useCustomProcessor' is set to Yes.
+useCustomQemu = No
+# Source of Qemu binary:  If 'No', Nix qemu-system-riscv64 will be used.
+pathToCustomQemu = /path/to/qemu
+# Path to an appropriate qemu binary to use when useCustomQemu is yes.
+useCustomHwTarget = No
+# In a many-board system, use the HW Target specified by "customHWTarget".
+# This option has to be consistent among all targets (in case of cyberPhys mode)
+customHwTarget = localhost:3121/xilinx_tcf/Digilent/210308XXXXXX
+# The HW Target to use if useCustomHwTarget is enabled.
+useCustomTargetIp = No
+# Use a custom IP address for the target.
+# This option has to be consistent among all targets (in case of cyberPhys mode).
+customTargetIp = XXX.XXX.XXX.XXX
+# The Target IP to use if useCustomTargetIp is enabled.
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+# besspin common options
+[common]
+openConsole = No
+# returns a console for FreeBSD/debian, and shows the UART output of FreeRTOS while running.
+gdbDebug = No
+# Detaches from Openocd to allow the user to connect a GDB process to the target.
+# "openConsole" has to be enabled. Instructions are printed out with the console.
+useCustomCredentials = No
+# If 'Yes', create a user with the credentials provided in 'userName' and
+# 'userPasswordHash'. If 'No', then the user account will have username
+# 'researcher' and password 'besspin_2020'.
+userName = researcher
+# Name of user to create.  Must be 1-14 characters long and may consist only of
+# ASCII alphanumeric characters.
+userPasswordHash = $6$xcnc07LxM26Xq$VBAn8.ZfCzEf5MEpftSsCndDaxfPs5gXWjdrvrHcSA6O6eRoV5etd9V8E.BE0/q4P8pGOz96Nav3PPuXOktmv.
+# Output of crypt(3) in SHA-512 mode with user's password as input
+# You can use: `mkpasswd -m sha-512 PASSWORD` on unix
+rootUserAccess = No
+# If 'Yes', gives user root access via passwordless su on Debian and FreeBSD.
+remoteTargetIp = 172.31.34.147
+# IP address on AWS to bind the FPGA to via a 1:1 NAT
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+[fett]
+buildApps = no
+# Building only available in fettTest mode.
+freertosFatFs = default
+# Only applicable in 'fettTest' mode and if 'buildApps' is enabled
+# [ default (ramdisk for vcu118 and dosblk for awsf1) | ramdisk | dosblk (only on awsf1) | sdcard (only on vcu118) ]
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+# build settings
+[build]
+cross-compiler = GCC
+# [ GCC | Clang ]
+linker = GCC
+# [ GCC | LLD ]
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+[evaluateSecurityTests]
+vulClasses = [bufferErrors, PPAC, resourceManagement, informationLeakage, numericErrors, hardwareSoC, injection]
+# List the vulClasses whose tests are to be executed.
+# Choose from: [bufferErrors, PPAC, resourceManagement, informationLeakage, numericErrors, hardwareSoC, injection]
+useCustomCWEsConfigsPath = No
+# If 'No', then the files in `${repo}/configSecurityTests` will be used by default.
+pathToCustomCWEsConfigs = /path/to/directory-containting-configs
+# The path to the directory containing the CWEs config files
+useCustomScoring = No
+# Load the settings in the [customizedScoring] section below.
+useCustomCompiling = No
+# Load the settings in the [customizedCompiling] section below.
+computeNaiveCWEsTally = Yes
+# Whether to compute the naive CWEs tally count and scores
+computeBesspinScale = Yes
+# Whether to compute the BESSPIN Scale if possible
+FreeRTOStimeout = 10
+# The FreeRTOS test execution requires a timeout. 10 seconds is a reasonable value.
+runUnixMultitaskingTests = Yes
+# If enabled, then the compatible and selected tests will run in the multitasking mode. 
+instancesPerTestPart = 1
+# The number of instances of each test part to spawn as separate processes when running multitasking tests.
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+[customizedScoring]
+stdoutKeywords = []
+# List of keywords (comma separated, white spaces) in stdout that means that the processor has detected a violation.
+gdbKeywords = []
+# List of keywords (comma separated, white spaces) in GDB output that means that the processor has detected a violation.
+funcCheckpoints = []
+# List of functions/methods/interrupts (comma separated, white spaces) reaching which means that the processor has detected a violation.
+memAddress = -1
+# The memory address to watch for detected violations. use -1 to disable.
+memResetValue = 0
+# The value (HEX) to which the tool should reset the memAddress after a violation detection.
+memViolationValues = []
+# List of values (HEX, comma separated) that indicate that a violation was detected. For example: [0x539, FFF, 1]
+# You may use [*] to indicate the use of every value except memResetValue. 
+useCustomFunction = No
+# Use a custom python script whose main will score instead of the settings above.
+pathToCustomFunction = /path/to/python/function
+# The path to the python script. It will be passed: 1. A list of the lines from the log file. 2. The Enum object SCORES. 
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+[customizedCompiling]
+useCustomMakefile = No
+# Use a custom Makefile. This makefile will be copied to the tests directory as 'Makefile', and be executed by 'make'.
+pathToCustomMakefile = /path/to/Makefile
+# The path to the custom makefile. 
+useCustomClang = No
+# Use a custom Clang binary.
+pathToCustomClang = /path/to/clang
+# The path to the custom Clang binary (passed to make as CLANG).
+useCustomSysroot = No
+# Use a custom sysroot.
+pathToCustomSysroot = /path/to/sysroot
+# The path to the custom sysroot directory (passed to make SYSROOT).
+gccDebian = default
+# [ default | linux9.2 | bareMetal8.3 | bareMetal9.2 ]
+# Applicable only to debian/GCC, default is linux9.2.
+# linux9.2: riscv64-unknown-linux-gnu-gcc v9.2 (built with nix)
+# bareMetal8.3: riscv64-unknown-elf-gcc v8.3 (provided in the docker container <galoisinc/besspin:gfe-gcc83>) 
+# bareMetal9.2: riscv64-unknown-elf-gcc v9.2 (built with nix)
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+# Vul Class: Buffer Errors
+[bufferErrors]
+useSelfAssessment = No
+# Enable to use the CWEsConfigs for the scores instead of running the tests
+useCustomErrorModel = No
+# Enable this option to use the error model in 'pathToCustomErrorModel', rather
+# than the default error model.  This allows for configuration of the types of
+# errors the generated tests will exercise.  See 'docs/constrainBufferErrors.md'
+# for a detailed description of how to use custom error models.
+pathToCustomErrorModel = /path/to/error/model.cfr
+# Path to the error model to use when 'useCustomErrorModel' is enabled.
+numericTypes = [ints, floats]
+# List the numeric types the generated tests should use.
+# Choose from [ints, floats]
+nTests    = 100
+# The number of random tests generated.  Must be at least 40 for FreeRTOS and
+# at least 100 for debian and FreeBSD.
+nSkip     = 0
+# Before generating `nTests` tests, generate and throw away `nSkip` tests
+useSeed   = No
+# Whether to use a specific seed (instead of a random one)
+seed      = 0
+# The seed for the random generation (if useSeed is enabled)
+heapSize  = 8M
+stackSize = 8K
+# Maximum heap and stack sizes. Understands suffixes K=1024, M=1024^2
+useExtraTests = No
+# If 'Yes', then look for C files in 'extraSources' to run in addition
+# to the generated tests.
+extraSources  = /path/to/extra/sources
+# Path to directory containing C files to run as additional test cases. Each
+# test should be a self-contained C file.
+csvFile = Yes
+# tabulates the test results in a CSV file [boolean]
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+# Vul Class: Permission, Privileges and Access Control
+[PPAC]
+useSelfAssessment = No
+# Enable to use the CWEsConfigs for the scores instead of running the tests
+runAllTests = Yes
+# If disabled, then the file ${CWEsConfigs}/PPAC.ini will be used to custom configure the tests
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+# Vul Class: Resource Management
+[resourceManagement]
+useSelfAssessment = No
+# Enable to use the CWEsConfigs for the scores instead of running the tests
+runAllTests = Yes
+# If disabled, then the file ${CWEsConfigs}/resourceManagement.ini will be used to custom configure the tests
+useSeed = No
+# Whether to use a specific seed (instead of a randomly generated one at runtime)
+seed = 0
+# The seed for the random generation (if `useSeed` is enabled)
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+# Vul Class: Information Leakage
+[informationLeakage]
+useSelfAssessment = No
+# Enable to use the CWEsConfigs for the scores instead of running the tests
+runAllTests = Yes
+# If disabled, then the file ${CWEsConfigs}/informationLeakage.ini will be used to custom configure the tests
+useSeed = No
+# Whether to use a specific seed (instead of a randomly generated one at runtime)
+seed = 0
+# The seed for the random generation (if `useSeed` is enabled)
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+# Vul Class: Numeric Errors
+[numericErrors]
+useSelfAssessment = No
+# Enable to use the CWEsConfigs for the scores instead of running the tests
+runAllTests = Yes
+# If disabled, then the file ${CWEsConfigs}/numericErrors.ini will be used to custom configure the tests
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+# Vul Class: Hardware Implementation / SoC
+[hardwareSoC]
+# useSelfAssessment = Yes # Internally enabled -- Self-assessment only.
+# Enable to use the CWEsConfigs for the scores instead of running the tests
+runAllTests = Yes
+# If disabled, then the file ${CWEsConfigs}/hardwareSoC.ini will be used to custom configure the tests
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+# Vul Class: Injection
+[injection]
+useSelfAssessment = No
+# Enable to use the CWEsConfigs for the scores instead of running the tests
+runAllTests = Yes
+# If disabled, then the file ${CWEsConfigs}/injection.ini will be used to custom configure the tests
+#--------------------------------------------------------------------------------

--- a/besspin/cyberPhys/configs/config-cyberphys.ini
+++ b/besspin/cyberPhys/configs/config-cyberphys.ini
@@ -17,7 +17,7 @@ mode = cyberPhys
 #--------------------------------------------------------------------------------
 #cyberPhys options and config file. This overwrites the `target` section
 [cyberPhys]
-nTargets = 3
+nTargets = 6
 # Number of different targets. Note that the number of sections `[target${i}]` has to match inside the cyberPhys config
 interactiveShell = Yes
 # Opens the cyberPhys interactive shell. If disabled, the tool will launch the targets then shut them down. 

--- a/besspin/cyberPhys/configs/cyberPhys-debian.ini
+++ b/besspin/cyberPhys/configs/cyberPhys-debian.ini
@@ -1,0 +1,92 @@
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# This is the configuration file for cyberPhys
+# User Help:
+# If you want to create your own file, please enable `useCustomCyberPhysConfig` and enter the path in
+# `pathToCustomCyberPhysConfig` in the besspin config file. Note that `myCyberPhys.ini` is git ignored ;)
+# Please fill-in the options as needed then run ./besspin.py
+# Keep the comments on seperate lines from values. Order of parameters does not matter, but section headers are required.
+# Parameters names are case sensitive.
+# For bool types, you can use 0/1, False/True, Yes/No [Case insensitive].
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+# The DEFAULT section overwrites the other sections ONLY if the option is not explicitly defined in the other targets.
+# If `nTargets == N` (besspin config), then there has to be sections `target1` --> `targetN`.
+[DEFAULT]
+binarySource = GFE
+# [ GFE | LMCO | Michigan | MIT | SRI-Cambridge ]
+sourceVariant = default
+# [ default | purecap | temporal | combo-100 | combo-015-017-100-101-103 ]
+# purecap and temporal are only compatible with SRI-Cambridge.
+# combo-100 and combo-015-017-100-101-103 are only compatible with LMCO on vcu118
+target = vcu118
+# [ qemu | vcu118 | awsf1 ]
+vcu118Mode = flashBoot
+# [ nonPersistent | flashProgramAndBoot | flashBoot ]. Only applicable if target is set to "vcu118".
+# You need to have physical (non-remote) access to the vcu118 board if you choose the flash options.
+processor = bluespec_p2
+# [bluespec_p1, chisel_p1, bluespec_p2, chisel_p2, bluespec_p3, chisel_p3]
+osImage = debian
+# [ debian | FreeRTOS | FreeBSD | busybox(limited) ]
+elfLoader = netboot
+# [ JTAG | netboot ]
+useCustomOsImage = No
+# Source of the OS image: If 'No', Nix/BESSPIN-LFS will be used.
+pathToCustomOsImage = /path/to/image
+# Path to the osImage in case 'useCustomOsImage' is set to Yes.
+useCustomProcessor = No
+# Source of the processor files: If 'No', Nix/BESSPIN-LFS will be used.
+pathToCustomProcessorSource = /path/to/source/directory
+# Path to a directory with all the files needed (following the structure of BESSPIN-LFS) to use the custom processor in case 'useCustomProcessor' is set to Yes.
+useCustomQemu = No
+# Source of Qemu binary:  If 'No', Nix qemu-system-riscv64 will be used.
+pathToCustomQemu = /path/to/qemu
+# Path to an appropriate qemu binary to use when useCustomQemu is yes.
+useCustomHwTarget = Yes
+# In a many-board system, use the HW Target specified by "customHWTarget".
+customHwTarget = localhost:3121/xilinx_tcf/Digilent/210308XXXXXX
+# The HW Target to use if useCustomHwTarget is enabled.
+useCustomTargetIp = Yes
+# Use a custom IP address for the targets
+customTargetIp = XXX.XXX.XXX.XXX
+# The Target IP to use if useCustomTargetIp is enabled.
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+[target1]
+# SCENARIO 1: Baseline
+# label = "Baseline Infotainment 1"
+vcu118Mode = flashBoot
+osImage = debian
+useCustomOsImage = Yes
+pathToCustomOsImage = BESSPIN-LFS/GFE/osImages/vcu118/debian_no-rsyslog.elf
+customTargetIp = 10.88.88.11
+customHwTarget = localhost:3121/xilinx_tcf/Digilent/210308A5F7BD
+# The HW Target to use if useCustomHwTarget is enabled.
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+[target2]
+# SCENARIO 2: Secure Infotainment
+# label = "Secure Infotainment"
+osImage = debian
+useCustomOsImage = Yes
+pathToCustomOsImage = BESSPIN-LFS/LMCO/osImages/vcu118/debian_noRsyslog.elf
+binarySource = LMCO
+sourceVariant = combo-100
+processor = chisel_p2
+customTargetIp = 10.88.88.21
+customHwTarget = localhost:3121/xilinx_tcf/Digilent/210308A471FB
+# The HW Target to use if useCustomHwTarget is enabled.
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+[target3]
+# SCENARIO 3: Secure ECU
+# label = "Baseline Infotainment 2"
+osImage = debian
+useCustomOsImage = Yes
+pathToCustomOsImage = BESSPIN-LFS/GFE/osImages/vcu118/debian_no-rsyslog.elf
+customTargetIp = 10.88.88.31
+customHwTarget = localhost:3121/xilinx_tcf/Digilent/210308AAF988
+# The HW Target to use if useCustomHwTarget is enabled.
+#--------------------------------------------------------------------------------

--- a/besspin/cyberPhys/configs/cyberPhys-freertos.ini
+++ b/besspin/cyberPhys/configs/cyberPhys-freertos.ini
@@ -1,0 +1,92 @@
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# This is the configuration file for cyberPhys
+# User Help:
+# If you want to create your own file, please enable `useCustomCyberPhysConfig` and enter the path in
+# `pathToCustomCyberPhysConfig` in the besspin config file. Note that `myCyberPhys.ini` is git ignored ;)
+# Please fill-in the options as needed then run ./besspin.py
+# Keep the comments on seperate lines from values. Order of parameters does not matter, but section headers are required.
+# Parameters names are case sensitive.
+# For bool types, you can use 0/1, False/True, Yes/No [Case insensitive].
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+# The DEFAULT section overwrites the other sections ONLY if the option is not explicitly defined in the other targets.
+# If `nTargets == N` (besspin config), then there has to be sections `target1` --> `targetN`.
+[DEFAULT]
+binarySource = GFE
+# [ GFE | LMCO | Michigan | MIT | SRI-Cambridge ]
+sourceVariant = default
+# [ default | purecap | temporal | combo-100 | combo-015-017-100-101-103 ]
+# purecap and temporal are only compatible with SRI-Cambridge.
+# combo-100 and combo-015-017-100-101-103 are only compatible with LMCO on vcu118
+target = vcu118
+# [ qemu | vcu118 | awsf1 ]
+vcu118Mode = nonPersistent
+# [ nonPersistent | flashProgramAndBoot | flashBoot ]. Only applicable if target is set to "vcu118".
+# You need to have physical (non-remote) access to the vcu118 board if you choose the flash options.
+processor = bluespec_p2
+# [bluespec_p1, chisel_p1, bluespec_p2, chisel_p2, bluespec_p3, chisel_p3]
+osImage = debian
+# [ debian | FreeRTOS | FreeBSD | busybox(limited) ]
+elfLoader = netboot
+# [ JTAG | netboot ]
+useCustomOsImage = No
+# Source of the OS image: If 'No', Nix/BESSPIN-LFS will be used.
+pathToCustomOsImage = /path/to/image
+# Path to the osImage in case 'useCustomOsImage' is set to Yes.
+useCustomProcessor = No
+# Source of the processor files: If 'No', Nix/BESSPIN-LFS will be used.
+pathToCustomProcessorSource = /path/to/source/directory
+# Path to a directory with all the files needed (following the structure of BESSPIN-LFS) to use the custom processor in case 'useCustomProcessor' is set to Yes.
+useCustomQemu = No
+# Source of Qemu binary:  If 'No', Nix qemu-system-riscv64 will be used.
+pathToCustomQemu = /path/to/qemu
+# Path to an appropriate qemu binary to use when useCustomQemu is yes.
+useCustomHwTarget = Yes
+# In a many-board system, use the HW Target specified by "customHWTarget".
+customHwTarget = localhost:3121/xilinx_tcf/Digilent/210308XXXXXX
+# The HW Target to use if useCustomHwTarget is enabled.
+useCustomTargetIp = Yes
+# Use a custom IP address for the targets
+customTargetIp = XXX.XXX.XXX.XXX
+# The Target IP to use if useCustomTargetIp is enabled.
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+[target1]
+# SCENARIO 1: Baseline
+# label = "Baseline ECU 1"
+vcu118Mode = nonPersistent
+osImage = FreeRTOS
+pathToCustomOsImage = BESSPIN-LFS/GFE/osImages/vcu118/FreeRTOS_demonstrator_1.elf
+useCustomOsImage = Yes
+customTargetIp = 10.88.88.12
+customHwTarget = localhost:3121/xilinx_tcf/Digilent/210308A5F099
+# The HW Target to use if useCustomHwTarget is enabled.
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+[target2]
+# SCENARIO 2: Secure Infotainment
+# label = "Baseline ECU 2"
+vcu118Mode = nonPersistent
+osImage = FreeRTOS
+pathToCustomOsImage = BESSPIN-LFS/GFE/osImages/vcu118/FreeRTOS_demonstrator_2.elf
+useCustomOsImage = Yes
+customTargetIp = 10.88.88.22
+customHwTarget = localhost:3121/xilinx_tcf/Digilent/210308A5F7BB
+# The HW Target to use if useCustomHwTarget is enabled.
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+[target3]
+# SCENARIO 3: Secure ECU
+# label = "Secure ECU"
+vcu118Mode = nonPersistent
+osImage = FreeRTOS
+binarySource = SRI-Cambridge
+useCustomOsImage = Yes
+pathToCustomOsImage = BESSPIN-LFS/SRI-Cambridge/osImages/vcu118/FreeRTOS.elf
+customTargetIp = 10.88.88.32
+customHwTarget = localhost:3121/xilinx_tcf/Digilent/210308A3B66F
+# The HW Target to use if useCustomHwTarget is enabled.
+#--------------------------------------------------------------------------------

--- a/besspin/cyberPhys/infotainment-server/debian/kill_listeners.sh
+++ b/besspin/cyberPhys/infotainment-server/debian/kill_listeners.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo `ss -lupn src :5002 | grep 5002 | awk -F " " '{printf $6 "\n"}' | sed 's/.\+pid=\([0-9]\+\).\+/\1/g'` | xargs kill &> /tmp/dump || true

--- a/besspin/cyberPhys/infotainment-server/debian/kill_listeners.sh
+++ b/besspin/cyberPhys/infotainment-server/debian/kill_listeners.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-echo `ss -lupn src :5002 | grep 5002 | awk -F " " '{printf $6 "\n"}' | sed 's/.\+pid=\([0-9]\+\).\+/\1/g'` | xargs kill &> /tmp/dump || true

--- a/besspin/cyberPhys/infotainmentserver.py
+++ b/besspin/cyberPhys/infotainmentserver.py
@@ -30,9 +30,6 @@ def install (xTarget):
         xTarget.terminateAndExit(f"{xTarget.targetIdInfo}Can't start infotainment server service on <{getSetting('osImage', targetId=xTarget.targetId)}>",
                                  exitCode=EXIT.Dev_Bug)
 
-    # Install the kill service script
-    xTarget.runCommand("mv kill_listeners.sh /opt/kill_listeners.sh",tee=appLog)
-
     printAndLog(f"{xTarget.targetIdInfo}infotainment server installed successfully.",tee=appLog)
 
 @decorate.debugWrap
@@ -51,7 +48,7 @@ def restart (xTarget):
     printAndLog(f"{xTarget.targetIdInfo}Restarting infotainment server service!", tee=appLog)
     serviceTimeout = 120
     if isEqSetting('osImage','debian',targetId=xTarget.targetId):
-        xTarget.runCommand("/opt/kill_listeners.sh",exitOnError=False,tee=appLog)
+        xTarget.runCommand("pkill infotainment_se",exitOnError=False,tee=appLog)
         xTarget.runCommand("systemctl stop infotainment-server.service", erroneousContents=["Failed to stop", "error code"], tee=appLog)
         xTarget.runCommand("systemctl start infotainment-server.service", erroneousContents=["Failed to start", "error code"], tee=appLog)
     elif isEqSetting('osImage','FreeBSD',targetId=xTarget.targetId):

--- a/besspin/cyberPhys/infotainmentserver.py
+++ b/besspin/cyberPhys/infotainmentserver.py
@@ -20,6 +20,7 @@ def install (xTarget):
         xTarget.runCommand("cp infotainment-server.service /lib/systemd/system/infotainment-server.service", erroneousContents="install:", tee=appLog)
         xTarget.runCommand("systemctl enable infotainment-server.service", timeout=serviceTimeout, tee=appLog)
         xTarget.runCommand("systemctl start infotainment-server.service", erroneousContents=["Failed to start", "error code"], tee=appLog)
+        xTarget.runCommand("mv kill_listeners.sh /opt/kill_listeners.sh",tee=appLog)
     elif isEqSetting('osImage','FreeBSD', targetId=xTarget.targetId):
         xTarget.runCommand("install -d /usr/local/etc/rc.d", tee=appLog)
         xTarget.runCommand("install infotainment-server.sh /usr/local/etc/rc.d/infotainment-server", erroneousContents="install:", tee=appLog)
@@ -48,7 +49,8 @@ def restart (xTarget):
     printAndLog(f"{xTarget.targetIdInfo}Restarting infotainment server service!", tee=appLog)
     serviceTimeout = 120
     if isEqSetting('osImage','debian',targetId=xTarget.targetId):
-        xTarget.runCommand("pkill infotainment_se",exitOnError=False,tee=appLog)
+        #xTarget.runCommand("pkill infotainment_se",exitOnError=False,tee=appLog)
+        xTarget.runCommand("/opt/kill_listeners.sh",exitOnError=False,tee=appLog)
         xTarget.runCommand("systemctl stop infotainment-server.service", erroneousContents=["Failed to stop", "error code"], tee=appLog)
         xTarget.runCommand("systemctl start infotainment-server.service", erroneousContents=["Failed to start", "error code"], tee=appLog)
     elif isEqSetting('osImage','FreeBSD',targetId=xTarget.targetId):

--- a/besspin/cyberPhys/infotainmentserver.py
+++ b/besspin/cyberPhys/infotainmentserver.py
@@ -49,6 +49,8 @@ def restart (xTarget):
     printAndLog(f"{xTarget.targetIdInfo}Restarting infotainment server service!", tee=appLog)
     serviceTimeout = 120
     if isEqSetting('osImage','debian',targetId=xTarget.targetId):
+        # NOTE: pkill should work too, keeping this as an alternative to
+        # the kill_listeners.sh script
         #xTarget.runCommand("pkill infotainment_se",exitOnError=False,tee=appLog)
         xTarget.runCommand("/opt/kill_listeners.sh",exitOnError=False,tee=appLog)
         xTarget.runCommand("systemctl stop infotainment-server.service", erroneousContents=["Failed to stop", "error code"], tee=appLog)

--- a/besspin/cyberPhys/launch.py
+++ b/besspin/cyberPhys/launch.py
@@ -266,7 +266,8 @@ def stopTtyLogging(targetId):
     xTarget = getSetting('targetObj',targetId=targetId)
     if (not isEnabled('isTtyLogging',targetId=targetId)):
         warnAndLog(f"{xTarget.targetIdInfo}stopTtyLogging: The TTY was not being logged!",doPrint=False)
-        return
+        return False
     getSetting('ttyLogger',targetId=targetId).stop()
     setSetting('isTtyLogging',False,targetId=targetId)
+    return True
 

--- a/besspin/cyberPhys/watchdog.py
+++ b/besspin/cyberPhys/watchdog.py
@@ -75,6 +75,9 @@ class Watchdog(ccomp.ComponentPoller):
 
     @recv_topic("base-topic")
     def _(self, msg, t):
+        # Disable ttyLogger
+        wasLogging = besspin.cyberPhys.launch.stopTtyLogging(self.targetId)
+
         """Filter received messages"""
         if msg == f"OTA_RESET {self.targetId}":
             printAndLog(f"OTA_RESET {self.targetId} requested")
@@ -86,3 +89,7 @@ class Watchdog(ccomp.ComponentPoller):
             # TODO: notify when reset completed
         elif msg == f"RESET {self.targetId}":
             self.reset_target("Reset requested")
+
+        # Re-enable ttyLogger
+        if (wasLogging):
+            besspin.cyberPhys.launch.startTtyLogging(self.targetId)


### PR DESCRIPTION
Fix the debian crashing on reset components.

`<runCommand>` should not be called while `TtyLogger` is up and running.